### PR TITLE
[FEAT] 카카오 로그인과 닉네임 중복 체크 API 구현

### DIFF
--- a/src/main/java/issueissyu/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/issueissyu/backend/domain/auth/controller/AuthController.java
@@ -2,10 +2,13 @@ package issueissyu.backend.domain.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import issueissyu.backend.domain.auth.dto.req.KakaoAppLoginReqDTO;
 import issueissyu.backend.domain.auth.dto.req.NicknameCheckReqDTO;
 import issueissyu.backend.domain.auth.dto.req.NaverAppLoginReqDTO;
+import issueissyu.backend.domain.auth.dto.res.KakaoAppLoginResDTO;
 import issueissyu.backend.domain.auth.dto.res.NaverAppLoginResDTO;
 import issueissyu.backend.domain.auth.dto.res.NicknameCheckResDTO;
+import issueissyu.backend.domain.auth.service.KakaoAppLoginService;
 import issueissyu.backend.domain.auth.service.NaverAppLoginService;
 import issueissyu.backend.domain.auth.dto.req.TokenReissueReqDTO;
 import issueissyu.backend.domain.auth.dto.res.TokenPairDTO;
@@ -36,6 +39,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final NaverAppLoginService naverAppLoginService;
+    private final KakaoAppLoginService kakaoAppLoginService;
 
     // 개발용 Dev Naver 콜백 확인 페이지
     // http://localhost:8080/dev/oauth2/authorization/naver 로그인 후 여기로 리다이렉트됨
@@ -123,6 +127,18 @@ public class AuthController {
         AuthSuccessCode successCode = result.isNew()
                 ? AuthSuccessCode.NAVER_LOGIN_200_1
                 : AuthSuccessCode.NAVER_LOGIN_200_2;
+        return ApiResponse.onSuccess(successCode, result);
+    }
+
+    @Operation(summary = "카카오 앱 로그인")
+    @PostMapping("/auth/login/kakao")
+    public ApiResponse<KakaoAppLoginResDTO> kakaoAppLogin(
+            @Valid @RequestBody KakaoAppLoginReqDTO request) {
+
+        KakaoAppLoginResDTO result = kakaoAppLoginService.login(request);
+        AuthSuccessCode successCode = result.isNew()
+                ? AuthSuccessCode.KAKAO_LOGIN_200_1
+                : AuthSuccessCode.KAKAO_LOGIN_200_2;
         return ApiResponse.onSuccess(successCode, result);
     }
 

--- a/src/main/java/issueissyu/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/issueissyu/backend/domain/auth/controller/AuthController.java
@@ -2,11 +2,14 @@ package issueissyu.backend.domain.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import issueissyu.backend.domain.auth.dto.req.NicknameCheckReqDTO;
 import issueissyu.backend.domain.auth.dto.req.NaverAppLoginReqDTO;
 import issueissyu.backend.domain.auth.dto.res.NaverAppLoginResDTO;
+import issueissyu.backend.domain.auth.dto.res.NicknameCheckResDTO;
 import issueissyu.backend.domain.auth.service.NaverAppLoginService;
 import issueissyu.backend.domain.auth.dto.req.TokenReissueReqDTO;
 import issueissyu.backend.domain.auth.dto.res.TokenPairDTO;
+import issueissyu.backend.domain.auth.exception.code.AuthErrorCode;
 import issueissyu.backend.domain.auth.exception.code.AuthSuccessCode;
 import issueissyu.backend.domain.auth.service.AuthService;
 import issueissyu.backend.global.api.ApiResponse;
@@ -127,6 +130,34 @@ public class AuthController {
     @PostMapping("/auth/refresh")
     public ApiResponse<TokenPairDTO> refresh(@Valid @RequestBody TokenReissueReqDTO request) {
         return ApiResponse.onSuccess(AuthSuccessCode.REFRESH_200, authService.reissue(request));
+    }
+
+    @Operation(summary = "닉네임 중복 확인", description = "입력한 닉네임의 형식 및 중복 여부를 확인합니다.")
+    @GetMapping("/auth/nickname")
+    public ApiResponse<NicknameCheckResDTO> checkNickname(
+            @RequestParam(required = false) String nickname,
+            @RequestBody(required = false) NicknameCheckReqDTO request
+    ) {
+        String targetNickname = nickname != null ? nickname : (request != null ? request.getNickname() : null);
+
+        NicknameCheckResDTO unavailable = NicknameCheckResDTO.builder()
+                .isAvailableNickname(false)
+                .build();
+
+        if (!authService.isValidNicknameFormat(targetNickname)) {
+            return ApiResponse.onFailure(AuthErrorCode.NICKNAME_400, unavailable);
+        }
+
+        if (authService.isNicknameDuplicated(targetNickname)) {
+            return ApiResponse.onFailure(AuthErrorCode.NICKNAME_409, unavailable);
+        }
+
+        NicknameCheckResDTO available = NicknameCheckResDTO.builder()
+                .isAvailableNickname(true)
+                .nickname(targetNickname)
+                .build();
+
+        return ApiResponse.onSuccess(AuthSuccessCode.NICKNAME_200, available);
     }
 
     @Operation(summary = "회원탈퇴", description = "인증된 사용자의 Redis 토큰·OAuth·User 레코드를 모두 삭제합니다.")

--- a/src/main/java/issueissyu/backend/domain/auth/dto/req/KakaoAppLoginReqDTO.java
+++ b/src/main/java/issueissyu/backend/domain/auth/dto/req/KakaoAppLoginReqDTO.java
@@ -1,0 +1,20 @@
+package issueissyu.backend.domain.auth.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 앱(안드로이드)에서 카카오 SDK로 발급받은 토큰을 백엔드로 전달하는 요청 DTO
+@Getter
+@NoArgsConstructor
+public class KakaoAppLoginReqDTO {
+
+    @JsonProperty("access_token")
+    @NotBlank
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    @NotBlank
+    private String refreshToken;
+}

--- a/src/main/java/issueissyu/backend/domain/auth/dto/req/NicknameCheckReqDTO.java
+++ b/src/main/java/issueissyu/backend/domain/auth/dto/req/NicknameCheckReqDTO.java
@@ -1,0 +1,13 @@
+package issueissyu.backend.domain.auth.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NicknameCheckReqDTO {
+
+    @JsonProperty("nickname")
+    private String nickname;
+}

--- a/src/main/java/issueissyu/backend/domain/auth/dto/res/KakaoAppLoginResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/auth/dto/res/KakaoAppLoginResDTO.java
@@ -1,0 +1,38 @@
+package issueissyu.backend.domain.auth.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+// 카카오 앱 로그인 성공 응답 DTO
+// isNew=true  -> user.tempUuid 반환 (온보딩 전 임시 아이디)
+// isNew=false -> user.uuid 반환 (확정 아이디)
+@Getter
+@Builder
+public class KakaoAppLoginResDTO {
+
+    private String accessToken;
+    private String refreshToken;
+
+    // 액세스 토큰 만료 시간 (초 단위)
+    private long expiresIn;
+
+    // 첫 로그인 여부 (true: 신규 회원 -> 온보딩, false: 기존 회원)
+    private boolean isNew;
+
+    private UserInfo user;
+
+    @Getter
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class UserInfo {
+        private String uuid;
+
+        @JsonProperty("temp_uuid")
+        private String tempUuid;
+
+        @JsonProperty("user_name")
+        private String userName;
+    }
+}

--- a/src/main/java/issueissyu/backend/domain/auth/dto/res/NicknameCheckResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/auth/dto/res/NicknameCheckResDTO.java
@@ -1,0 +1,17 @@
+package issueissyu.backend.domain.auth.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NicknameCheckResDTO {
+
+    @JsonProperty("is_available_nickname")
+    private final boolean isAvailableNickname;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final String nickname;
+}

--- a/src/main/java/issueissyu/backend/domain/auth/exception/AuthException.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/AuthException.java
@@ -1,0 +1,15 @@
+package issueissyu.backend.domain.auth.exception;
+
+import issueissyu.backend.domain.auth.exception.code.AuthErrorCode;
+import issueissyu.backend.global.exception.GeneralException;
+
+public class AuthException extends GeneralException {
+
+    public AuthException(AuthErrorCode code) {
+        super(code);
+    }
+
+    public static AuthException of(AuthErrorCode code) {
+        return new AuthException(code);
+    }
+}

--- a/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
@@ -12,6 +12,7 @@ public enum AuthErrorCode implements BaseErrorCode {
 
     NAVER_LOGIN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "NAVER_LOGIN_401", "유효하지 않은 값 존재(만료된 인가코드 등)"),
     NAVER_API_FAILED(HttpStatus.BAD_GATEWAY, "NAVER_5021", "네이버 서버 응답에 실패했습니다."),
+    KAKAO_LOGIN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "KAKAO_LOGIN_401", "유효하지 않은 값이 존재합니다."),
     NICKNAME_400(HttpStatus.BAD_REQUEST, "NICKNAME_400", "닉네임은 15자 이내의 영문, 숫자, 한글만 사용 가능합니다."),
     NICKNAME_409(HttpStatus.CONFLICT, "NICKNAME_409", "이미 사용 중인 닉네임입니다."),
 

--- a/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
@@ -13,7 +13,6 @@ public enum AuthErrorCode implements BaseErrorCode {
     NAVER_LOGIN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "NAVER_LOGIN_401", "유효하지 않은 값 존재(만료된 인가코드 등)"),
     NAVER_API_FAILED(HttpStatus.BAD_GATEWAY, "NAVER_5021", "네이버 서버 응답에 실패했습니다."),
     KAKAO_LOGIN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "KAKAO_LOGIN_401", "유효하지 않은 값이 존재합니다."),
-    TERM_400(HttpStatus.BAD_REQUEST, "TERM_400", "필수 약관(SERVICE, PRIVACY)에 모두 동의해야 합니다."),
     NICKNAME_400(HttpStatus.BAD_REQUEST, "NICKNAME_400", "닉네임은 15자 이내의 영문, 숫자, 한글만 사용 가능합니다."),
     NICKNAME_409(HttpStatus.CONFLICT, "NICKNAME_409", "이미 사용 중인 닉네임입니다."),
 

--- a/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
@@ -12,6 +12,8 @@ public enum AuthErrorCode implements BaseErrorCode {
 
     NAVER_LOGIN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "NAVER_LOGIN_401", "유효하지 않은 값 존재(만료된 인가코드 등)"),
     NAVER_API_FAILED(HttpStatus.BAD_GATEWAY, "NAVER_5021", "네이버 서버 응답에 실패했습니다."),
+    NICKNAME_400(HttpStatus.BAD_REQUEST, "NICKNAME_400", "닉네임은 15자 이내의 영문, 숫자, 한글만 사용 가능합니다."),
+    NICKNAME_409(HttpStatus.CONFLICT, "NICKNAME_409", "이미 사용 중인 닉네임입니다."),
 
     REFRESH_INVALID(HttpStatus.UNAUTHORIZED, "REFRESH_401", "토큰 재발급에 실패했습니다."),
     LOGOUT_INVALID(HttpStatus.UNAUTHORIZED, "LOGOUT_401", "유효하지 않은 토큰입니다."),

--- a/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
@@ -13,6 +13,7 @@ public enum AuthErrorCode implements BaseErrorCode {
     NAVER_LOGIN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "NAVER_LOGIN_401", "유효하지 않은 값 존재(만료된 인가코드 등)"),
     NAVER_API_FAILED(HttpStatus.BAD_GATEWAY, "NAVER_5021", "네이버 서버 응답에 실패했습니다."),
     KAKAO_LOGIN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "KAKAO_LOGIN_401", "유효하지 않은 값이 존재합니다."),
+    TERM_400(HttpStatus.BAD_REQUEST, "TERM_400", "필수 약관(SERVICE, PRIVACY)에 모두 동의해야 합니다."),
     NICKNAME_400(HttpStatus.BAD_REQUEST, "NICKNAME_400", "닉네임은 15자 이내의 영문, 숫자, 한글만 사용 가능합니다."),
     NICKNAME_409(HttpStatus.CONFLICT, "NICKNAME_409", "이미 사용 중인 닉네임입니다."),
 

--- a/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthSuccessCode.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthSuccessCode.java
@@ -15,7 +15,6 @@ public enum AuthSuccessCode implements BaseSuccessCode {
     NAVER_LOGIN_200_2(HttpStatus.OK, "NAVER_LOGIN_200_2", "로그인에 성공했습니다."),
     KAKAO_LOGIN_200_1(HttpStatus.OK, "KAKAO_LOGIN_200_1", "첫 로그인에 성공했습니다."),
     KAKAO_LOGIN_200_2(HttpStatus.OK, "KAKAO_LOGIN_200_2", "로그인에 성공했습니다."),
-    TERM_200(HttpStatus.OK, "TERM_200", "약관 동의에 성공했습니다."),
     NICKNAME_200(HttpStatus.OK, "NICKNAME_200", "사용 가능한 닉네임입니다."),
 
     REFRESH_200(HttpStatus.OK, "REFRESH_200", "토큰 재발급에 성공했습니다."),

--- a/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthSuccessCode.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthSuccessCode.java
@@ -15,6 +15,7 @@ public enum AuthSuccessCode implements BaseSuccessCode {
     NAVER_LOGIN_200_2(HttpStatus.OK, "NAVER_LOGIN_200_2", "로그인에 성공했습니다."),
     KAKAO_LOGIN_200_1(HttpStatus.OK, "KAKAO_LOGIN_200_1", "첫 로그인에 성공했습니다."),
     KAKAO_LOGIN_200_2(HttpStatus.OK, "KAKAO_LOGIN_200_2", "로그인에 성공했습니다."),
+    TERM_200(HttpStatus.OK, "TERM_200", "약관 동의에 성공했습니다."),
     NICKNAME_200(HttpStatus.OK, "NICKNAME_200", "사용 가능한 닉네임입니다."),
 
     REFRESH_200(HttpStatus.OK, "REFRESH_200", "토큰 재발급에 성공했습니다."),

--- a/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthSuccessCode.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthSuccessCode.java
@@ -13,6 +13,8 @@ public enum AuthSuccessCode implements BaseSuccessCode {
     // 네이버 앱 로그인 성공 코드
     NAVER_LOGIN_200_1(HttpStatus.OK, "NAVER_LOGIN_200_1", "첫 로그인에 성공했습니다."),
     NAVER_LOGIN_200_2(HttpStatus.OK, "NAVER_LOGIN_200_2", "로그인에 성공했습니다."),
+    KAKAO_LOGIN_200_1(HttpStatus.OK, "KAKAO_LOGIN_200_1", "첫 로그인에 성공했습니다."),
+    KAKAO_LOGIN_200_2(HttpStatus.OK, "KAKAO_LOGIN_200_2", "로그인에 성공했습니다."),
     NICKNAME_200(HttpStatus.OK, "NICKNAME_200", "사용 가능한 닉네임입니다."),
 
     REFRESH_200(HttpStatus.OK, "REFRESH_200", "토큰 재발급에 성공했습니다."),

--- a/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthSuccessCode.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthSuccessCode.java
@@ -13,6 +13,7 @@ public enum AuthSuccessCode implements BaseSuccessCode {
     // 네이버 앱 로그인 성공 코드
     NAVER_LOGIN_200_1(HttpStatus.OK, "NAVER_LOGIN_200_1", "첫 로그인에 성공했습니다."),
     NAVER_LOGIN_200_2(HttpStatus.OK, "NAVER_LOGIN_200_2", "로그인에 성공했습니다."),
+    NICKNAME_200(HttpStatus.OK, "NICKNAME_200", "사용 가능한 닉네임입니다."),
 
     REFRESH_200(HttpStatus.OK, "REFRESH_200", "토큰 재발급에 성공했습니다."),
     LOGOUT_200(HttpStatus.OK, "LOGOUT_200", "로그아웃 되었습니다."),

--- a/src/main/java/issueissyu/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package issueissyu.backend.domain.auth.service;
 
 import issueissyu.backend.domain.auth.dto.req.TokenReissueReqDTO;
 import issueissyu.backend.domain.auth.dto.res.TokenPairDTO;
+import issueissyu.backend.domain.auth.exception.AuthException;
 import issueissyu.backend.domain.auth.exception.code.AuthErrorCode;
 import issueissyu.backend.domain.user.entity.OAuth;
 import issueissyu.backend.domain.user.entity.User;
@@ -9,7 +10,6 @@ import issueissyu.backend.domain.user.enums.SocialType;
 import issueissyu.backend.domain.user.repository.OAuthRepository;
 import issueissyu.backend.domain.user.repository.UserRepository;
 import issueissyu.backend.domain.user.util.AppUuid;
-import issueissyu.backend.global.exception.GeneralException;
 import issueissyu.backend.global.redis.RefreshTokenRedisStore;
 import issueissyu.backend.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +35,7 @@ public class AuthService {
     public NaverUserResult findOrCreateDevNaverUser(NaverUserProfile profile) {
         String providerId = profile.id();
         if (providerId == null || providerId.isBlank()) {
-            throw GeneralException.of(AuthErrorCode.NAVER_LOGIN_UNAUTHORIZED);
+            throw AuthException.of(AuthErrorCode.NAVER_LOGIN_UNAUTHORIZED);
         }
 
         Optional<OAuth> existing = oAuthRepository.findBySocialTypeAndProviderIdWithUser(
@@ -60,28 +60,28 @@ public class AuthService {
 
         // 서명·만료 검증
         if (!jwtTokenProvider.validateToken(incoming)) {
-            throw GeneralException.of(AuthErrorCode.REFRESH_INVALID);
+            throw AuthException.of(AuthErrorCode.REFRESH_INVALID);
         }
         // refresh 타입인지 확인
         if (!JwtTokenProvider.TOKEN_TYPE_REFRESH.equals(jwtTokenProvider.parseTokenType(incoming))) {
-            throw GeneralException.of(AuthErrorCode.REFRESH_INVALID);
+            throw AuthException.of(AuthErrorCode.REFRESH_INVALID);
         }
 
         String uid      = jwtTokenProvider.parseUid(incoming);
         String provider = jwtTokenProvider.parseProvider(incoming);
         if (provider == null) {
-            throw GeneralException.of(AuthErrorCode.REFRESH_INVALID);
+            throw AuthException.of(AuthErrorCode.REFRESH_INVALID);
         }
 
         // Redis 저장 토큰과 일치 여부 확인
         String stored = refreshTokenRedisStore.find(uid, provider)
-                .orElseThrow(() -> GeneralException.of(AuthErrorCode.REFRESH_INVALID));
+                .orElseThrow(() -> AuthException.of(AuthErrorCode.REFRESH_INVALID));
         if (!stored.equals(incoming)) {
-            throw GeneralException.of(AuthErrorCode.REFRESH_INVALID);
+            throw AuthException.of(AuthErrorCode.REFRESH_INVALID);
         }
 
         userRepository.findById(uid)
-                .orElseThrow(() -> GeneralException.of(AuthErrorCode.REFRESH_INVALID));
+                .orElseThrow(() -> AuthException.of(AuthErrorCode.REFRESH_INVALID));
 
         // 새 토큰 발급 + Redis 갱신
         String newAccess  = jwtTokenProvider.createAccessToken(uid);
@@ -113,7 +113,7 @@ public class AuthService {
     public NaverUserResult findOrCreateNaverAppUser(NaverUserProfile profile) {
         String providerId = profile.id();
         if (providerId == null || providerId.isBlank()) {
-            throw GeneralException.of(AuthErrorCode.NAVER_LOGIN_UNAUTHORIZED);
+            throw AuthException.of(AuthErrorCode.NAVER_LOGIN_UNAUTHORIZED);
         }
 
         Optional<OAuth> existing = oAuthRepository.findBySocialTypeAndProviderIdWithUser(

--- a/src/main/java/issueissyu/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/AuthService.java
@@ -18,10 +18,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[A-Za-z0-9가-힣]{1,15}$");
 
     private final UserRepository userRepository;
     private final OAuthRepository oAuthRepository;
@@ -146,5 +149,14 @@ public class AuthService {
                 .uid(uid)
                 .userName(name != null && !name.isBlank() ? name : null)
                 .build());
+    }
+
+    // 닉네임 형식 검증
+    public boolean isValidNicknameFormat(String nickname) {
+        return nickname != null && NICKNAME_PATTERN.matcher(nickname).matches();
+    }
+
+    public boolean isNicknameDuplicated(String nickname) {
+        return userRepository.existsByNickname(nickname);
     }
 }

--- a/src/main/java/issueissyu/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/AuthService.java
@@ -132,12 +132,48 @@ public class AuthService {
         return new NaverUserResult(user, true);
     }
 
+    // 카카오 앱 로그인
+    @Transactional
+    public KakaoUserResult findOrCreateKakaoAppUser(KakaoUserProfile profile) {
+        String providerId = profile.id();
+        if (providerId == null || providerId.isBlank()) {
+            throw AuthException.of(AuthErrorCode.KAKAO_LOGIN_UNAUTHORIZED);
+        }
+
+        Optional<OAuth> existing = oAuthRepository.findBySocialTypeAndProviderIdWithUser(
+                SocialType.KAKAO, providerId);
+
+        if (existing.isPresent()) {
+            return new KakaoUserResult(existing.get().getUser(), false);
+        }
+
+        User user = createNewKakaoAppUser(profile);
+        oAuthRepository.save(OAuth.builder()
+                .user(user)
+                .providerId(providerId)
+                .socialType(SocialType.KAKAO)
+                .build());
+        return new KakaoUserResult(user, true);
+    }
+
     private User createNewNaverAppUser(NaverUserProfile profile) {
         String uid  = AppUuid.newUid();
         String name = profile.name();
         return userRepository.save(User.builder()
                 .uid(uid)
                 .userName(name != null && !name.isBlank() ? name : null)
+                .build());
+    }
+
+    private User createNewKakaoAppUser(KakaoUserProfile profile) {
+        String uid = AppUuid.newUid();
+        String name = profile.name() != null ? profile.name().trim() : null;
+        if (name == null || name.isBlank()) {
+            throw AuthException.of(AuthErrorCode.KAKAO_LOGIN_UNAUTHORIZED);
+        }
+        return userRepository.save(User.builder()
+                .uid(uid)
+                .userName(name)
                 .build());
     }
 

--- a/src/main/java/issueissyu/backend/domain/auth/service/KakaoAppLoginService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/KakaoAppLoginService.java
@@ -1,0 +1,99 @@
+package issueissyu.backend.domain.auth.service;
+
+import issueissyu.backend.domain.auth.dto.req.KakaoAppLoginReqDTO;
+import issueissyu.backend.domain.auth.dto.res.KakaoAppLoginResDTO;
+import issueissyu.backend.domain.auth.exception.AuthException;
+import issueissyu.backend.domain.auth.exception.code.AuthErrorCode;
+import issueissyu.backend.domain.user.enums.SocialType;
+import issueissyu.backend.global.redis.RefreshTokenRedisStore;
+import issueissyu.backend.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoAppLoginService {
+
+    private static final String KAKAO_USER_INFO_PATH = "/v2/user/me";
+    private static final String KAKAO_PROVIDER = SocialType.KAKAO.name().toLowerCase();
+
+    private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRedisStore refreshTokenRedisStore;
+    @Qualifier("kakaoRestClient")
+    private final RestClient restClient;
+
+    public KakaoAppLoginResDTO login(KakaoAppLoginReqDTO req) {
+        KakaoUserProfile profile = fetchKakaoUserProfile(req.getAccessToken());
+
+        KakaoUserResult result = authService.findOrCreateKakaoAppUser(profile);
+        String uid = result.user().getUid();
+        String userName = result.user().getUserName();
+        boolean isNew = result.isNew();
+
+        String accessToken = jwtTokenProvider.createAccessToken(uid);
+        String refreshToken = jwtTokenProvider.createRefreshToken(uid, KAKAO_PROVIDER);
+        refreshTokenRedisStore.save(uid, KAKAO_PROVIDER, refreshToken,
+                Duration.ofMillis(jwtTokenProvider.getRefreshExpMs()));
+
+        KakaoAppLoginResDTO.UserInfo userInfo = isNew
+                ? KakaoAppLoginResDTO.UserInfo.builder()
+                .tempUuid(uid)
+                .userName(userName)
+                .build()
+                : KakaoAppLoginResDTO.UserInfo.builder()
+                .uuid(uid)
+                .userName(userName)
+                .build();
+
+        return KakaoAppLoginResDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .expiresIn(jwtTokenProvider.getAccessExpMs() / 1000)
+                .isNew(isNew)
+                .user(userInfo)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private KakaoUserProfile fetchKakaoUserProfile(String kakaoAccessToken) {
+        try {
+            Map<String, Object> body = restClient.get()
+                    .uri(KAKAO_USER_INFO_PATH)
+                    .header("Authorization", "Bearer " + kakaoAccessToken)
+                    .retrieve()
+                    .body(Map.class);
+
+            if (body == null || body.get("id") == null) {
+                throw AuthException.of(AuthErrorCode.KAKAO_LOGIN_UNAUTHORIZED);
+            }
+
+            Object idValue = body.get("id");
+            String id = String.valueOf(idValue);
+
+            String name = "";
+            Map<String, Object> properties = (Map<String, Object>) body.get("properties");
+            if (properties != null && properties.get("nickname") != null) {
+                name = String.valueOf(properties.get("nickname")).trim();
+            }
+
+            if (id.isBlank() || name.isBlank()) {
+                throw AuthException.of(AuthErrorCode.KAKAO_LOGIN_UNAUTHORIZED);
+            }
+
+            log.debug("카카오 앱 로그인 사용자 정보 조회 성공: id={}, nickname={}", id, name);
+            return new KakaoUserProfile(id, name);
+        } catch (RestClientException e) {
+            log.error("카카오 사용자 정보 API 호출 실패", e);
+            throw AuthException.of(AuthErrorCode.KAKAO_LOGIN_UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/issueissyu/backend/domain/auth/service/KakaoUserProfile.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/KakaoUserProfile.java
@@ -1,0 +1,4 @@
+package issueissyu.backend.domain.auth.service;
+
+public record KakaoUserProfile(String id, String name) {
+}

--- a/src/main/java/issueissyu/backend/domain/auth/service/KakaoUserResult.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/KakaoUserResult.java
@@ -1,0 +1,6 @@
+package issueissyu.backend.domain.auth.service;
+
+import issueissyu.backend.domain.user.entity.User;
+
+public record KakaoUserResult(User user, boolean isNew) {
+}

--- a/src/main/java/issueissyu/backend/domain/auth/service/NaverAppLoginService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/NaverAppLoginService.java
@@ -2,9 +2,9 @@ package issueissyu.backend.domain.auth.service;
 
 import issueissyu.backend.domain.auth.dto.req.NaverAppLoginReqDTO;
 import issueissyu.backend.domain.auth.dto.res.NaverAppLoginResDTO;
+import issueissyu.backend.domain.auth.exception.AuthException;
 import issueissyu.backend.domain.auth.exception.code.AuthErrorCode;
 import issueissyu.backend.domain.user.enums.SocialType;
-import issueissyu.backend.global.exception.GeneralException;
 import issueissyu.backend.global.redis.RefreshTokenRedisStore;
 import issueissyu.backend.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -81,14 +81,14 @@ public class NaverAppLoginService {
                     .body(Map.class);
 
             if (body == null) {
-                throw GeneralException.of(AuthErrorCode.NAVER_API_FAILED);
+                throw AuthException.of(AuthErrorCode.NAVER_API_FAILED);
             }
 
             String resultCode = (String) body.get("resultcode");
             if (!"00".equals(resultCode)) {
                 log.warn("네이버 사용자 정보 API 오류 응답: resultcode={}, message={}",
                         resultCode, body.get("message"));
-                throw GeneralException.of(AuthErrorCode.NAVER_LOGIN_UNAUTHORIZED);
+                throw AuthException.of(AuthErrorCode.NAVER_LOGIN_UNAUTHORIZED);
             }
 
             Map<String, Object> response = (Map<String, Object>) body.get("response");
@@ -96,7 +96,7 @@ public class NaverAppLoginService {
             String name = (String) response.getOrDefault("name", "");
 
             if (id == null || id.isBlank()) {
-                throw GeneralException.of(AuthErrorCode.NAVER_LOGIN_UNAUTHORIZED);
+                throw AuthException.of(AuthErrorCode.NAVER_LOGIN_UNAUTHORIZED);
             }
 
             log.debug("네이버 앱 로그인 사용자 정보 조회 성공: id={}, name={}", id, name);
@@ -104,7 +104,7 @@ public class NaverAppLoginService {
 
         } catch (RestClientException e) {
             log.error("네이버 사용자 정보 API 호출 실패", e);
-            throw GeneralException.of(AuthErrorCode.NAVER_API_FAILED);
+            throw AuthException.of(AuthErrorCode.NAVER_API_FAILED);
         }
     }
 }

--- a/src/main/java/issueissyu/backend/domain/user/entity/User.java
+++ b/src/main/java/issueissyu/backend/domain/user/entity/User.java
@@ -35,7 +35,7 @@ public class User extends BaseEntity {
     @Column(unique = true, length = 13)
     private String phone;
 
-    @Column(length = 15)
+    @Column(unique = true, length = 15)
     private String nickname;
 
     @Type(PGpointUserType.class)

--- a/src/main/java/issueissyu/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/issueissyu/backend/domain/user/repository/UserRepository.java
@@ -4,4 +4,5 @@ import issueissyu.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, String> {
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/issueissyu/backend/global/config/RestClientConfig.java
+++ b/src/main/java/issueissyu/backend/global/config/RestClientConfig.java
@@ -20,4 +20,11 @@ public class RestClientConfig {
                 .baseUrl("https://openapi.naver.com")
                 .build();
     }
+
+    @Bean
+    public RestClient kakaoRestClient(RestClient.Builder restClientBuilder) {
+        return restClientBuilder
+                .baseUrl("https://kapi.kakao.com")
+                .build();
+    }
 }

--- a/src/main/java/issueissyu/backend/global/config/SecurityConfig.java
+++ b/src/main/java/issueissyu/backend/global/config/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/dev/oauth2/**", "/dev/login/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/auth/login/naver").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/auth/login/kakao").permitAll()
                         .requestMatchers(HttpMethod.POST, "/auth/refresh").permitAll()
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html",
                                 "/v3/api-docs/**", "/swagger-resources/**").permitAll()

--- a/src/main/java/issueissyu/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/issueissyu/backend/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package issueissyu.backend.global.exception;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
+import issueissyu.backend.domain.auth.exception.code.AuthErrorCode;
 import issueissyu.backend.global.api.ApiResponse;
 import issueissyu.backend.global.api.code.BaseErrorCode;
 import issueissyu.backend.global.api.code.GeneralErrorCode;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,6 +44,21 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<Object> onThrowException(GeneralException generalException,
                                                    HttpServletRequest request) {
         return handleExceptionInternal(generalException, generalException.getCode(), null, request);
+    }
+
+    // DataIntegrityViolationException
+    @ExceptionHandler(value = DataIntegrityViolationException.class)
+    public ResponseEntity<Object> onDataIntegrityViolationException(DataIntegrityViolationException e,
+                                                                    HttpServletRequest request) {
+        String message = e.getMostSpecificCause() != null
+                ? e.getMostSpecificCause().getMessage()
+                : e.getMessage();
+
+        if (message != null && message.toLowerCase().contains("nickname")) {
+            return handleExceptionInternal(e, AuthErrorCode.NICKNAME_409, null, request);
+        }
+
+        return handleExceptionInternal(e, GeneralErrorCode.BAD_REQUEST, null, request);
     }
 
     // MethodArgumentNotValidException


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #18 
- resolve #19 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.

카오 로그인과 닉네임 중복 체크 API를 구현합니다.

## 체크리스트
- [ ] Reviewers, Assignees, Labels를 모두 등록했나요?
- [ ] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.