### PR TITLE
[BUG] 댓글 페이징 삭제

### DIFF
--- a/src/main/java/issueissyu/backend/domain/pin/controller/PinCommentController.java
+++ b/src/main/java/issueissyu/backend/domain/pin/controller/PinCommentController.java
@@ -10,9 +10,6 @@ import issueissyu.backend.domain.pin.service.query.CommentQueryService;
 import issueissyu.backend.global.api.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,8 +18,9 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "Pin Comment", description = "핀 댓글 API")
 @RestController
@@ -34,16 +32,13 @@ public class PinCommentController {
 
     @Operation(summary = "핀 댓글 목록 조회")
     @GetMapping
-    public ApiResponse<Page<CommentResDTO>> getComments(
+    public ApiResponse<List<CommentResDTO>> getComments(
             @PathVariable Long pinId,
-            @AuthenticationPrincipal String uid,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @AuthenticationPrincipal String uid
     ) {
-        Pageable pageable = PageRequest.of(page, size);
         return ApiResponse.onSuccess(
                 PinSuccessCode.PIN_COMMENTS_200,
-                commentQueryService.getComments(pinId, uid, pageable)
+                commentQueryService.getComments(pinId, uid)
         );
     }
 

--- a/src/main/java/issueissyu/backend/domain/pin/controller/PinCommentController.java
+++ b/src/main/java/issueissyu/backend/domain/pin/controller/PinCommentController.java
@@ -11,9 +11,8 @@ import issueissyu.backend.global.api.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,6 +21,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Pin Comment", description = "핀 댓글 API")
@@ -37,8 +37,10 @@ public class PinCommentController {
     public ApiResponse<Page<CommentResDTO>> getComments(
             @PathVariable Long pinId,
             @AuthenticationPrincipal String uid,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
     ) {
+        Pageable pageable = PageRequest.of(page, size);
         return ApiResponse.onSuccess(
                 PinSuccessCode.PIN_COMMENTS_200,
                 commentQueryService.getComments(pinId, uid, pageable)

--- a/src/main/java/issueissyu/backend/domain/pin/repository/CommentRepository.java
+++ b/src/main/java/issueissyu/backend/domain/pin/repository/CommentRepository.java
@@ -1,15 +1,14 @@
 package issueissyu.backend.domain.pin.repository;
 
 import issueissyu.backend.domain.pin.entity.Comment;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    Page<Comment> findAllByPinPinId(Long pinId, Pageable pageable);
+    List<Comment> findAllByPinPinIdOrderByCreatedAtDesc(Long pinId);
 
     Optional<Comment> findByCommentIdAndPinPinId(Long commentId, Long pinId);
 }

--- a/src/main/java/issueissyu/backend/domain/pin/repository/CommentRepository.java
+++ b/src/main/java/issueissyu/backend/domain/pin/repository/CommentRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    Page<Comment> findAllByPinPinIdOrderByCreatedAtAsc(Long pinId, Pageable pageable);
+    Page<Comment> findAllByPinPinId(Long pinId, Pageable pageable);
 
     Optional<Comment> findByCommentIdAndPinPinId(Long commentId, Long pinId);
 }

--- a/src/main/java/issueissyu/backend/domain/pin/service/query/CommentQueryService.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/query/CommentQueryService.java
@@ -1,9 +1,9 @@
 package issueissyu.backend.domain.pin.service.query;
 
 import issueissyu.backend.domain.pin.dto.res.CommentResDTO;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface CommentQueryService {
-    Page<CommentResDTO> getComments(Long pinId, String uid, Pageable pageable);
+    List<CommentResDTO> getComments(Long pinId, String uid);
 }

--- a/src/main/java/issueissyu/backend/domain/pin/service/query/CommentQueryServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/query/CommentQueryServiceImpl.java
@@ -8,7 +8,9 @@ import issueissyu.backend.domain.pin.repository.CommentRepository;
 import issueissyu.backend.domain.pin.repository.PinRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +27,14 @@ public class CommentQueryServiceImpl implements CommentQueryService {
             throw PinException.of(PinErrorCode.PIN_NOT_FOUND);
         }
 
-        return commentRepository.findAllByPinPinIdOrderByCreatedAtAsc(pinId, pageable)
+        // 댓글 정렬 기준 최신순으로 고정
+        Pageable latestPageable = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        return commentRepository.findAllByPinPinId(pinId, latestPageable)
                 .map(comment -> CommentConverter.toCommentResDTO(comment, uid));
     }
 }

--- a/src/main/java/issueissyu/backend/domain/pin/service/query/CommentQueryServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/query/CommentQueryServiceImpl.java
@@ -7,12 +7,10 @@ import issueissyu.backend.domain.pin.exception.code.PinErrorCode;
 import issueissyu.backend.domain.pin.repository.CommentRepository;
 import issueissyu.backend.domain.pin.repository.PinRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,19 +20,14 @@ public class CommentQueryServiceImpl implements CommentQueryService {
     private final PinRepository pinRepository;
 
     @Override
-    public Page<CommentResDTO> getComments(Long pinId, String uid, Pageable pageable) {
+    public List<CommentResDTO> getComments(Long pinId, String uid) {
         if (!pinRepository.existsById(pinId)) {
             throw PinException.of(PinErrorCode.PIN_NOT_FOUND);
         }
 
-        // 댓글 정렬 기준 최신순으로 고정
-        Pageable latestPageable = PageRequest.of(
-                pageable.getPageNumber(),
-                pageable.getPageSize(),
-                Sort.by(Sort.Direction.DESC, "createdAt")
-        );
-
-        return commentRepository.findAllByPinPinId(pinId, latestPageable)
-                .map(comment -> CommentConverter.toCommentResDTO(comment, uid));
+        // 댓글 정렬 기준은 최신순(createdAt DESC)으로 고정
+        return commentRepository.findAllByPinPinIdOrderByCreatedAtDesc(pinId).stream()
+                .map(comment -> CommentConverter.toCommentResDTO(comment, uid))
+                .toList();
     }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #31 

## ✨ 작업 개요
댓글 정렬 방식을 인기순/최신순 분기로 받았던 버그가 있어 최신순 단일 고정으로 변경했습니다.
정렬 파라미터 수신 로직을 제거하고 쿼리를 최신순으로 고정했습니다.
=> 회의 후 댓글 목록 조회에는 페이징 을 빼기로 하였습니다!

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.