### PR TITLE
[FEAT] 최초 로그인 시 기본 프로필 설정

### DIFF
--- a/src/main/java/issueissyu/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/issueissyu/backend/domain/auth/controller/AuthController.java
@@ -211,7 +211,7 @@ public class AuthController {
         return ApiResponse.onSuccess(AuthSuccessCode.NICKNAME_200, available);
     }
 
-    @Operation(summary = "회원탈퇴", description = "인증된 사용자의 Redis 토큰·OAuth·User 레코드를 모두 삭제합니다.")
+    @Operation(summary = "회원탈퇴", description = "인증된 사용자의 연관 데이터(pin·댓글·알림 등)를 정리한 뒤 Redis 토큰·OAuth·User 레코드를 삭제합니다.")
     @DeleteMapping("/api/auth/signout")
     public ApiResponse<Void> signout(@AuthenticationPrincipal String uid) {
         authService.signout(uid);

--- a/src/main/java/issueissyu/backend/domain/auth/dto/res/OnboardingResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/auth/dto/res/OnboardingResDTO.java
@@ -11,4 +11,13 @@ public class OnboardingResDTO {
 
     @JsonProperty("social_type")
     private String socialType;
+
+    @JsonProperty("user_custom_collection_id")
+    private Long userCustomCollectionId;
+
+    @JsonProperty("custom_collection_id")
+    private Long customCollectionId;
+
+    @JsonProperty("custom_collection_name")
+    private String customCollectionName;
 }

--- a/src/main/java/issueissyu/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/AuthService.java
@@ -10,6 +10,7 @@ import issueissyu.backend.domain.user.enums.SocialType;
 import issueissyu.backend.domain.user.repository.OAuthRepository;
 import issueissyu.backend.domain.user.repository.UserRepository;
 import issueissyu.backend.domain.user.repository.UserTermRepository;
+import issueissyu.backend.domain.user.service.UserSignOutCleaner;
 import issueissyu.backend.domain.user.util.AppUuid;
 import issueissyu.backend.global.redis.RefreshTokenRedisStore;
 import issueissyu.backend.global.security.JwtTokenProvider;
@@ -30,6 +31,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final OAuthRepository oAuthRepository;
     private final UserTermRepository userTermRepository;
+    private final UserSignOutCleaner userSignOutCleaner;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRedisStore refreshTokenRedisStore;
 
@@ -102,10 +104,11 @@ public class AuthService {
         refreshTokenRedisStore.deleteAll(uid);
     }
 
-    // 회원탈퇴: Redis 토큰 → OAuth → UserTerm → User 순으로 삭제
+    // 회원탈퇴: Redis 토큰 → 사용자 연관 행(PC·알림 등) → OAuth → UserTerm → User 순으로 삭제
     @Transactional
     public void signout(String uid) {
         refreshTokenRedisStore.deleteAll(uid);
+        userSignOutCleaner.deleteRowsReferencingUser(uid);
         oAuthRepository.deleteByUserUid(uid);
         userTermRepository.deleteByUserUid(uid);
         userRepository.deleteById(uid);

--- a/src/main/java/issueissyu/backend/domain/auth/service/OnboardingService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/OnboardingService.java
@@ -4,6 +4,10 @@ import issueissyu.backend.domain.auth.dto.req.OnboardingReqDTO;
 import issueissyu.backend.domain.auth.dto.res.OnboardingResDTO;
 import issueissyu.backend.domain.auth.exception.AuthException;
 import issueissyu.backend.domain.auth.exception.code.AuthErrorCode;
+import issueissyu.backend.domain.collection.entity.CustomCollection;
+import issueissyu.backend.domain.collection.entity.mapping.UserCustomCollection;
+import issueissyu.backend.domain.collection.repository.CustomCollectionRepository;
+import issueissyu.backend.domain.collection.repository.UserCustomCollectionRepository;
 import issueissyu.backend.domain.user.entity.OAuth;
 import issueissyu.backend.domain.user.entity.User;
 import issueissyu.backend.domain.user.repository.OAuthRepository;
@@ -16,8 +20,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OnboardingService {
 
+    private static final String DEFAULT_PROFILE_NAME = "default";
+
     private final UserRepository userRepository;
     private final OAuthRepository oAuthRepository;
+    private final CustomCollectionRepository customCollectionRepository;
+    private final UserCustomCollectionRepository userCustomCollectionRepository;
 
     @Transactional
     public OnboardingResDTO onboard(String uid, OnboardingReqDTO request) {
@@ -37,9 +45,29 @@ public class OnboardingService {
 
         user.onboard(request.getNickname(), request.getEmail(), request.getPhone());
 
+        CustomCollection defaultProfile = customCollectionRepository
+                .findByCustomCollectionName(DEFAULT_PROFILE_NAME)
+                .orElseThrow(() -> AuthException.of(AuthErrorCode.ONBOAREDING_400));
+
+        UserCustomCollection savedProfile =
+                userCustomCollectionRepository
+                        .findByUser_UidAndCustomCollection_CustomCollectionName(
+                                uid, DEFAULT_PROFILE_NAME)
+                        .orElseGet(
+                                () ->
+                                        userCustomCollectionRepository.save(
+                                                UserCustomCollection.builder()
+                                                        .user(user)
+                                                        .customCollection(
+                                                                defaultProfile)
+                                                        .build()));
+
         return OnboardingResDTO.builder()
                 .uuid(user.getUid())
                 .socialType(oauth.getSocialType().name())
+                .userCustomCollectionId(savedProfile.getUserCustomCollectionId())
+                .customCollectionId(defaultProfile.getCustomCollectionId())
+                .customCollectionName(defaultProfile.getCustomCollectionName())
                 .build();
     }
 }

--- a/src/main/java/issueissyu/backend/domain/collection/repository/CustomCollectionRepository.java
+++ b/src/main/java/issueissyu/backend/domain/collection/repository/CustomCollectionRepository.java
@@ -1,4 +1,10 @@
 package issueissyu.backend.domain.collection.repository;
 
-public interface CustomCollectionRepository {
+import issueissyu.backend.domain.collection.entity.CustomCollection;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomCollectionRepository extends JpaRepository<CustomCollection, Long> {
+
+    Optional<CustomCollection> findByCustomCollectionName(String customCollectionName);
 }

--- a/src/main/java/issueissyu/backend/domain/collection/repository/UserCustomCollectionRepository.java
+++ b/src/main/java/issueissyu/backend/domain/collection/repository/UserCustomCollectionRepository.java
@@ -1,4 +1,11 @@
 package issueissyu.backend.domain.collection.repository;
 
-public interface UserCustomCollectionRepository {
+import issueissyu.backend.domain.collection.entity.mapping.UserCustomCollection;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserCustomCollectionRepository extends JpaRepository<UserCustomCollection, Long> {
+
+    Optional<UserCustomCollection> findByUser_UidAndCustomCollection_CustomCollectionName(
+            String uid, String customCollectionName);
 }

--- a/src/main/java/issueissyu/backend/domain/user/service/UserSignOutCleaner.java
+++ b/src/main/java/issueissyu/backend/domain/user/service/UserSignOutCleaner.java
@@ -1,0 +1,96 @@
+package issueissyu.backend.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserSignOutCleaner {
+
+    private static final String PIN_IDS_OWNED_BY_USER =
+            "(SELECT pin_id FROM pin WHERE uid = ?)";
+
+    private static final String ISSUE_PIN_IDS_FOR_OWNED_PINS =
+            "(SELECT issue_pin_id FROM issue_pin WHERE pin_id IN "
+                    + PIN_IDS_OWNED_BY_USER
+                    + ")";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void deleteRowsReferencingUser(String uid) {
+        jdbcTemplate.update(
+                "DELETE FROM problem_solver_image WHERE problem_solver_id IN ("
+                        + "SELECT problem_solver_id FROM problem_solver WHERE uid = ? "
+                        + "OR issue_pin_id IN "
+                        + ISSUE_PIN_IDS_FOR_OWNED_PINS
+                        + ")",
+                uid,
+                uid);
+        jdbcTemplate.update(
+                "DELETE FROM problem_solver WHERE uid = ? OR issue_pin_id IN "
+                        + ISSUE_PIN_IDS_FOR_OWNED_PINS,
+                uid,
+                uid);
+        jdbcTemplate.update(
+                "DELETE FROM issue_petition WHERE uid = ? OR issue_pin_id IN "
+                        + ISSUE_PIN_IDS_FOR_OWNED_PINS,
+                uid,
+                uid);
+        jdbcTemplate.update(
+                "DELETE FROM issue_pin WHERE pin_id IN " + PIN_IDS_OWNED_BY_USER, uid);
+
+        jdbcTemplate.update(
+                "DELETE FROM community WHERE pin_id IN " + PIN_IDS_OWNED_BY_USER, uid);
+        jdbcTemplate.update(
+                "DELETE FROM pin_emoji WHERE pin_id IN "
+                        + PIN_IDS_OWNED_BY_USER
+                        + " OR uid = ?",
+                uid,
+                uid);
+        jdbcTemplate.update(
+                "DELETE FROM \"comment\" WHERE pin_id IN "
+                        + PIN_IDS_OWNED_BY_USER
+                        + " OR uid = ?",
+                uid,
+                uid);
+        jdbcTemplate.update(
+                "DELETE FROM declaration WHERE pin_id IN "
+                        + PIN_IDS_OWNED_BY_USER
+                        + " OR uid = ?",
+                uid,
+                uid);
+        jdbcTemplate.update(
+                "DELETE FROM event_pin WHERE pin_id IN " + PIN_IDS_OWNED_BY_USER, uid);
+        jdbcTemplate.update(
+                "DELETE FROM communication_pin WHERE pin_id IN " + PIN_IDS_OWNED_BY_USER,
+                uid);
+        jdbcTemplate.update(
+                "DELETE FROM pin_location WHERE pin_id IN " + PIN_IDS_OWNED_BY_USER, uid);
+        jdbcTemplate.update(
+                "DELETE FROM pin_image WHERE pin_id IN " + PIN_IDS_OWNED_BY_USER, uid);
+        jdbcTemplate.update("DELETE FROM pin WHERE uid = ?", uid);
+
+        jdbcTemplate.update(
+                "DELETE FROM like_alarm WHERE user_alarm_id IN "
+                        + "(SELECT user_alarm_id FROM user_alarm WHERE uid = ?)",
+                uid);
+        jdbcTemplate.update(
+                "DELETE FROM hot_alarm WHERE user_alarm_id IN "
+                        + "(SELECT user_alarm_id FROM user_alarm WHERE uid = ?)",
+                uid);
+        jdbcTemplate.update(
+                "DELETE FROM event_alarm WHERE user_alarm_id IN "
+                        + "(SELECT user_alarm_id FROM user_alarm WHERE uid = ?)",
+                uid);
+        jdbcTemplate.update(
+                "DELETE FROM store_alarm WHERE user_alarm_id IN "
+                        + "(SELECT user_alarm_id FROM user_alarm WHERE uid = ?)",
+                uid);
+        jdbcTemplate.update("DELETE FROM user_alarm WHERE uid = ?", uid);
+
+        jdbcTemplate.update("DELETE FROM user_custom_collection WHERE uid = ?", uid);
+        jdbcTemplate.update("DELETE FROM user_location WHERE uid = ?", uid);
+        jdbcTemplate.update("DELETE FROM user_emoji WHERE uid = ?", uid);
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #41

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.

최초 로그인 시 기본 프로필을 설정하도록 합니다.
회원탈퇴에 빠진 쿼리들을 추가합니다.

API 실행 테스트를 위한 임시 데이터 삽입 쿼리문입니다.
```sql
INSERT INTO custom_collection (custom_collection_name, custom_collection_s3_key, custom_collection_s3_url)
VALUES (
        'default', '123456789', 'http://temp_image'
       );
```

## 체크리스트
- [X] Reviewers, Assignees, Labels를 모두 등록했나요?
- [X] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
온보딩
<img width="1408" height="790" alt="image" src="https://github.com/user-attachments/assets/51325b89-27c0-4228-9615-b5ef970bd787" />

회원탈퇴
<img width="1405" height="602" alt="image" src="https://github.com/user-attachments/assets/9730b97f-fa02-4890-b98e-486392f828ff" />

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

지난 이야기이긴 하지만,, #27 PR에서 User 엔터티에 user_profile_image 컬럼이 추가되었는데 혹시 어디에 쓰는 건가용? custom_collection 테이블의 custom_collection_s3_url을 저장하는 것인지 궁금합니닷.