### PR TITLE
[FEAT] 핀 공감하기 API

### DIFF
--- a/src/main/java/issueissyu/backend/domain/pin/controller/PinLikeController.java
+++ b/src/main/java/issueissyu/backend/domain/pin/controller/PinLikeController.java
@@ -1,0 +1,30 @@
+package issueissyu.backend.domain.pin.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import issueissyu.backend.domain.pin.dto.res.PinLikeResDTO;
+import issueissyu.backend.domain.pin.exception.code.PinSuccessCode;
+import issueissyu.backend.domain.pin.service.command.PinLikeCommandService;
+import issueissyu.backend.global.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Pin Like", description = "핀 공감 관련 API")
+@RestController
+@RequestMapping("/api/pins")
+@RequiredArgsConstructor
+public class PinLikeController {
+
+    private final PinLikeCommandService pinLikeCommandService;
+
+    @Operation(summary = "핀 공감", description = "사용자가 핀에 공감합니다. 한 번 공감한 핀에는 다시 요청할 수 없고, 취소는 제공하지 않습니다.")
+    @PostMapping("/{pinId}/like")
+    public ApiResponse<PinLikeResDTO> likePin(
+            @PathVariable Long pinId, @AuthenticationPrincipal String uid) {
+        return ApiResponse.onSuccess(PinSuccessCode.PIN_LIKE_200, pinLikeCommandService.likePin(pinId, uid));
+    }
+}

--- a/src/main/java/issueissyu/backend/domain/pin/dto/res/PinLikeResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/pin/dto/res/PinLikeResDTO.java
@@ -1,0 +1,6 @@
+package issueissyu.backend.domain.pin.dto.res;
+
+import lombok.Builder;
+
+@Builder
+public record PinLikeResDTO(long pinId, int pinLikeCount, boolean isLike) {}

--- a/src/main/java/issueissyu/backend/domain/pin/entity/Pin.java
+++ b/src/main/java/issueissyu/backend/domain/pin/entity/Pin.java
@@ -61,4 +61,8 @@ public class Pin extends BaseEntity {
     public void assignUser(User user) {
         this.user = user;
     }
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
 }

--- a/src/main/java/issueissyu/backend/domain/pin/entity/Pin.java
+++ b/src/main/java/issueissyu/backend/domain/pin/entity/Pin.java
@@ -30,7 +30,7 @@ public class Pin extends BaseEntity {
 
     @Builder.Default
     @Column(name = "like_count", nullable = false)
-    private long likeCount = 0L;
+    private int likeCount = 0;
 
     @Column(name = "pin_title", nullable = false, length = 100)
     private String pinTitle;

--- a/src/main/java/issueissyu/backend/domain/pin/exception/code/PinErrorCode.java
+++ b/src/main/java/issueissyu/backend/domain/pin/exception/code/PinErrorCode.java
@@ -19,7 +19,12 @@ public enum PinErrorCode implements BaseErrorCode {
 
     // 핀 댓글
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_NOT_FOUND_404_3", "존재하지 않는 댓글입니다."),
-    COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT_FORBIDDEN_403_2", "댓글 수정/삭제 권한이 없습니다.");
+    COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT_FORBIDDEN_403_2", "댓글 수정/삭제 권한이 없습니다."),
+
+    // 핀 공감
+    PIN_LIKE_ALREADY(HttpStatus.BAD_REQUEST, "PIN_LIKE_400_1", "이미 공감된 핀입니다."),
+    PIN_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "PIN_LIKE_404", "존재하지 않는 핀 입니다."),
+    PIN_LIKE_INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PIN_LIKE_500", "핀 공감하기 중 서버 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/issueissyu/backend/domain/pin/exception/code/PinErrorCode.java
+++ b/src/main/java/issueissyu/backend/domain/pin/exception/code/PinErrorCode.java
@@ -22,9 +22,7 @@ public enum PinErrorCode implements BaseErrorCode {
     COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT_FORBIDDEN_403_2", "댓글 수정/삭제 권한이 없습니다."),
 
     // 핀 공감
-    PIN_LIKE_ALREADY(HttpStatus.BAD_REQUEST, "PIN_LIKE_400_1", "이미 공감된 핀입니다."),
-    PIN_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "PIN_LIKE_404", "존재하지 않는 핀 입니다."),
-    PIN_LIKE_INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PIN_LIKE_500", "핀 공감하기 중 서버 오류가 발생했습니다.");
+    PIN_LIKE_ALREADY(HttpStatus.BAD_REQUEST, "PIN_LIKE_400_1", "이미 공감된 핀입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/issueissyu/backend/domain/pin/exception/code/PinSuccessCode.java
+++ b/src/main/java/issueissyu/backend/domain/pin/exception/code/PinSuccessCode.java
@@ -19,7 +19,10 @@ public enum PinSuccessCode implements BaseSuccessCode {
     PIN_COMMENTS_200(HttpStatus.OK, "PIN_COMMENTS_200", "핀 댓글 목록 조회에 성공했습니다."),
     CREATE_COMMENT_200(HttpStatus.OK, "CREATE_COMMENT_200", "핀 댓글 작성에 성공했습니다."),
     UPDATE_COMMENT_200(HttpStatus.OK, "UPDATE_COMMENT_200", "핀 댓글 수정에 성공했습니다."),
-    DELETE_COMMENT_200(HttpStatus.OK, "DELETE_COMMENT_200", "핀 댓글 삭제에 성공했습니다.");
+    DELETE_COMMENT_200(HttpStatus.OK, "DELETE_COMMENT_200", "핀 댓글 삭제에 성공했습니다."),
+
+    // 핀 공감
+    PIN_LIKE_200(HttpStatus.OK, "PIN_LIKE_200", "핀 공감에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/issueissyu/backend/domain/pin/repository/PinRepository.java
+++ b/src/main/java/issueissyu/backend/domain/pin/repository/PinRepository.java
@@ -1,9 +1,11 @@
 package issueissyu.backend.domain.pin.repository;
 
 import issueissyu.backend.domain.pin.entity.Pin;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,4 +14,8 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
     @EntityGraph(attributePaths = "user")
     @Query("select p from Pin p where p.pinId = :id")
     Optional<Pin> fetchDetailWithAuthor(@Param("id") Long pinId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Pin p where p.pinId = :pinId")
+    Optional<Pin> findWithPessimisticWriteByPinId(@Param("pinId") Long pinId);
 }

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinLikeCommandService.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinLikeCommandService.java
@@ -1,0 +1,8 @@
+package issueissyu.backend.domain.pin.service.command;
+
+import issueissyu.backend.domain.pin.dto.res.PinLikeResDTO;
+
+public interface PinLikeCommandService {
+
+    PinLikeResDTO likePin(Long pinId, String uid);
+}

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinLikeCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinLikeCommandServiceImpl.java
@@ -32,7 +32,7 @@ public class PinLikeCommandServiceImpl implements PinLikeCommandService {
                 userRepository.findById(uid).orElseThrow(() -> GeneralException.of(GeneralErrorCode.USER_NOT_FOUND));
         Pin pin = pinRepository
                 .findWithPessimisticWriteByPinId(pinId)
-                .orElseThrow(() -> PinException.of(PinErrorCode.PIN_LIKE_NOT_FOUND));
+                .orElseThrow(() -> PinException.of(PinErrorCode.PIN_NOT_FOUND));
 
         if (pinLikeRepository.existsByPin_PinIdAndUser_Uid(pinId, uid)) {
             throw PinException.of(PinErrorCode.PIN_LIKE_ALREADY);

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinLikeCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinLikeCommandServiceImpl.java
@@ -1,0 +1,56 @@
+package issueissyu.backend.domain.pin.service.command;
+
+import issueissyu.backend.domain.pin.dto.res.PinLikeResDTO;
+import issueissyu.backend.domain.pin.entity.Pin;
+import issueissyu.backend.domain.pin.entity.mapping.PinLike;
+import issueissyu.backend.domain.pin.exception.PinException;
+import issueissyu.backend.domain.pin.exception.code.PinErrorCode;
+import issueissyu.backend.domain.pin.repository.PinLikeRepository;
+import issueissyu.backend.domain.pin.repository.PinRepository;
+import issueissyu.backend.domain.user.entity.User;
+import issueissyu.backend.domain.user.repository.UserRepository;
+import issueissyu.backend.global.api.code.GeneralErrorCode;
+import issueissyu.backend.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PinLikeCommandServiceImpl implements PinLikeCommandService {
+
+    private final PinRepository pinRepository;
+    private final PinLikeRepository pinLikeRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public PinLikeResDTO likePin(Long pinId, String uid) {
+        User user =
+                userRepository.findById(uid).orElseThrow(() -> GeneralException.of(GeneralErrorCode.USER_NOT_FOUND));
+        Pin pin = pinRepository
+                .findWithPessimisticWriteByPinId(pinId)
+                .orElseThrow(() -> PinException.of(PinErrorCode.PIN_LIKE_NOT_FOUND));
+
+        if (pinLikeRepository.existsByPin_PinIdAndUser_Uid(pinId, uid)) {
+            throw PinException.of(PinErrorCode.PIN_LIKE_ALREADY);
+        }
+
+        PinLike pinLike = PinLike.builder().pin(pin).user(user).build();
+        try {
+            pinLikeRepository.saveAndFlush(pinLike);
+        } catch (DataIntegrityViolationException e) {
+            throw PinException.of(PinErrorCode.PIN_LIKE_ALREADY);
+        }
+
+        pin.incrementLikeCount();
+
+        return PinLikeResDTO.builder()
+                .pinId(pinId)
+                .pinLikeCount(pin.getLikeCount())
+                .isLike(true)
+                .build();
+    }
+}

--- a/src/main/java/issueissyu/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/issueissyu/backend/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import issueissyu.backend.domain.auth.exception.code.AuthErrorCode;
+import issueissyu.backend.domain.pin.exception.code.PinErrorCode;
 import issueissyu.backend.global.api.ApiResponse;
 import issueissyu.backend.global.api.code.BaseErrorCode;
 import issueissyu.backend.global.api.code.GeneralErrorCode;
@@ -88,6 +89,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
         e.printStackTrace();
+        if (request instanceof ServletWebRequest servletWebRequest
+                && "POST".equalsIgnoreCase(servletWebRequest.getRequest().getMethod())) {
+            String uri = servletWebRequest.getRequest().getRequestURI();
+            if (uri != null && uri.matches("/api/pins/\\d+/like")) {
+                return handleExceptionInternal(
+                        e, PinErrorCode.PIN_LIKE_INTERNAL_ERROR, HttpHeaders.EMPTY, servletWebRequest.getRequest());
+            }
+        }
         return handleExceptionInternalFalse(e, GeneralErrorCode.INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY,
                 GeneralErrorCode.INTERNAL_SERVER_ERROR.getReason().getHttpStatus(), request, e.getMessage());
     }

--- a/src/main/java/issueissyu/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/issueissyu/backend/global/exception/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import issueissyu.backend.domain.auth.exception.code.AuthErrorCode;
-import issueissyu.backend.domain.pin.exception.code.PinErrorCode;
 import issueissyu.backend.global.api.ApiResponse;
 import issueissyu.backend.global.api.code.BaseErrorCode;
 import issueissyu.backend.global.api.code.GeneralErrorCode;
@@ -89,14 +88,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
         e.printStackTrace();
-        if (request instanceof ServletWebRequest servletWebRequest
-                && "POST".equalsIgnoreCase(servletWebRequest.getRequest().getMethod())) {
-            String uri = servletWebRequest.getRequest().getRequestURI();
-            if (uri != null && uri.matches("/api/pins/\\d+/like")) {
-                return handleExceptionInternal(
-                        e, PinErrorCode.PIN_LIKE_INTERNAL_ERROR, HttpHeaders.EMPTY, servletWebRequest.getRequest());
-            }
-        }
         return handleExceptionInternalFalse(e, GeneralErrorCode.INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY,
                 GeneralErrorCode.INTERNAL_SERVER_ERROR.getReason().getHttpStatus(), request, e.getMessage());
     }


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #51

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.

핀 공감하기 API를 개발합니다.
사용자가 공감을 누르면 pin_like 테이블에 INSERT 함과 동시에, Pin 테이블의 like_count를 UPDATE 합니다.
따라서, pin_like saveAndFlush 후 pin.incrementLikeCount() → INSERT 직후 카운트 증가하는 한 트랙잭션을 가집니다.

동시성 문제를 방지하기 위해 Pessimistic Lock을 걸어두었습니다.
PinRepository 에서 비관적 락을 선언함을 확인 할 수 있습니다.


## 체크리스트
- [X] Reviewers, Assignees, Labels를 모두 등록했나요?
- [X] .gitignore 설정을 하였나요?
- [X] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
성공
<img width="1407" height="773" alt="image" src="https://github.com/user-attachments/assets/21afb5ca-90f3-40b5-873e-395633ba551e" />

존재하지 않는 핀 id 입력할 경우
<img width="1407" height="773" alt="image" src="https://github.com/user-attachments/assets/bc688635-35eb-4c5c-b39e-5acd6c143384" />

공감한 핀에 재공감할 경우
<img width="1407" height="732" alt="image" src="https://github.com/user-attachments/assets/f44ccbcb-241a-4bf6-a2fb-af5dd42d2c45" />

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.