### PR TITLE
[BUG] Redis TLS 설정 누락으로 인한 Redis 연결 실패 및 504 에러 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -122,6 +122,10 @@ spring:
     redis:
       host: ${VALKEY_HOST}
       port: ${VALKEY_PORT}
+      ssl:
+        enabled: true
+      timeout: 3s
+      connect-timeout: 3s
   sql:
     init:
       mode: never


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #60 

## ✨ 작업 개요
> Valkey(ElastiCache Redis) 전송 중 암호화가 활성화된 환경에서 SSL 설정이 누락되어 Redis 연결이 실패하고, 로그인 API 호출 시 504 Gateway Timeout이 발생하는 문제를 해결했습니다.
> develop 환경에서 Redis 연결 시 TLS를 사용하도록 설정을 추가하고, 연결 지연 시 빠르게 실패하도록 timeout 옵션을 함께 적용했습니다.

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)

## 🧐 집중 리뷰 요청