### PR TITLE
[BUG] 댓글 수정/삭제 API 불필요한 pinId 삭제

### DIFF
--- a/src/main/java/issueissyu/backend/domain/pin/controller/PinCommentController.java
+++ b/src/main/java/issueissyu/backend/domain/pin/controller/PinCommentController.java
@@ -24,14 +24,14 @@ import java.util.List;
 
 @Tag(name = "Pin Comment", description = "핀 댓글 API")
 @RestController
-@RequestMapping("/api/pins/{pinId}/comments")
+@RequestMapping("/api/pins")
 @RequiredArgsConstructor
 public class PinCommentController {
     private final CommentQueryService commentQueryService;
     private final CommentCommandService commentCommandService;
 
-    @Operation(summary = "핀 댓글 목록 조회")
-    @GetMapping
+    @Operation(summary = "핀 댓글 목록 조회", description = "특정 핀 댓글을 최신순으로 정렬하여 제공합니다.")
+    @GetMapping("/{pinId}/comments")
     public ApiResponse<List<CommentResDTO>> getComments(
             @PathVariable Long pinId,
             @AuthenticationPrincipal String uid
@@ -43,7 +43,7 @@ public class PinCommentController {
     }
 
     @Operation(summary = "핀 댓글 작성")
-    @PostMapping
+    @PostMapping("/{pinId}/comments")
     public ApiResponse<CommentResDTO> createComment(
             @PathVariable Long pinId,
             @AuthenticationPrincipal String uid,
@@ -56,27 +56,25 @@ public class PinCommentController {
     }
 
     @Operation(summary = "핀 댓글 수정")
-    @PatchMapping("/{commentId}")
+    @PatchMapping("/comments/{commentId}")
     public ApiResponse<CommentResDTO> updateComment(
-            @PathVariable Long pinId,
             @PathVariable Long commentId,
             @AuthenticationPrincipal String uid,
             @Valid @RequestBody CommentReqDTO request
     ) {
         return ApiResponse.onSuccess(
                 PinSuccessCode.UPDATE_COMMENT_200,
-                commentCommandService.updateComment(pinId, commentId, uid, request)
+                commentCommandService.updateComment(commentId, uid, request)
         );
     }
 
     @Operation(summary = "핀 댓글 삭제")
-    @DeleteMapping("/{commentId}")
+    @DeleteMapping("/comments/{commentId}")
     public ApiResponse<Void> deleteComment(
-            @PathVariable Long pinId,
             @PathVariable Long commentId,
             @AuthenticationPrincipal String uid
     ) {
-        commentCommandService.deleteComment(pinId, commentId, uid);
+        commentCommandService.deleteComment(commentId, uid);
         return ApiResponse.onSuccess(PinSuccessCode.DELETE_COMMENT_200, null);
     }
 }

--- a/src/main/java/issueissyu/backend/domain/pin/converter/CommentConverter.java
+++ b/src/main/java/issueissyu/backend/domain/pin/converter/CommentConverter.java
@@ -15,6 +15,7 @@ public class CommentConverter {
                 .profileImageUrl(comment.getUser().getProfileImageUrl())
                 .commentContent(comment.getCommentContent())
                 .isMine(comment.getUser().getUid().equals(uid))
+                .edited(comment.isEdited())
                 .createdAt(comment.getCreatedAt())
                 .build();
     }

--- a/src/main/java/issueissyu/backend/domain/pin/converter/CommentConverter.java
+++ b/src/main/java/issueissyu/backend/domain/pin/converter/CommentConverter.java
@@ -10,7 +10,6 @@ public class CommentConverter {
     public static CommentResDTO toCommentResDTO(Comment comment, String uid) {
         return CommentResDTO.builder()
                 .commentId(comment.getCommentId())
-                .uid(comment.getUser().getUid())
                 .nickname(comment.getUser().getNickname())
                 .profileImageUrl(comment.getUser().getProfileImageUrl())
                 .commentContent(comment.getCommentContent())

--- a/src/main/java/issueissyu/backend/domain/pin/dto/res/CommentResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/pin/dto/res/CommentResDTO.java
@@ -27,6 +27,9 @@ public class CommentResDTO {
     @Schema(description = "내 댓글 여부", example = "true")
     private boolean isMine;
 
+    @Schema(description = "수정 여부", example = "true")
+    private boolean edited;
+
     @Schema(description = "댓글 생성 시각")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/issueissyu/backend/domain/pin/dto/res/CommentResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/pin/dto/res/CommentResDTO.java
@@ -12,9 +12,6 @@ public class CommentResDTO {
     @Schema(description = "댓글 ID", example = "1")
     private Long commentId;
 
-    @Schema(description = "작성자 uid", example = "2f1f3f84-7a83-4e7f-8f09-7f2c1a93f236")
-    private String uid;
-
     @Schema(description = "작성자 닉네임", example = "이슈쟁이")
     private String nickname;
 

--- a/src/main/java/issueissyu/backend/domain/pin/entity/Comment.java
+++ b/src/main/java/issueissyu/backend/domain/pin/entity/Comment.java
@@ -13,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -41,7 +42,12 @@ public class Comment extends BaseEntity {
     @Column(name = "comment_content", nullable = false, length = 1000)
     private String commentContent;
 
+    @Builder.Default
+    @Column(name = "is_edited", nullable = false)
+    private boolean edited = false;
+
     public void updateContent(String commentContent) {
         this.commentContent = commentContent;
+        this.edited = true;
     }
 }

--- a/src/main/java/issueissyu/backend/domain/pin/repository/CommentRepository.java
+++ b/src/main/java/issueissyu/backend/domain/pin/repository/CommentRepository.java
@@ -1,14 +1,27 @@
 package issueissyu.backend.domain.pin.repository;
 
 import issueissyu.backend.domain.pin.entity.Comment;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    @EntityGraph(attributePaths = {"user"})
     List<Comment> findAllByPinPinIdOrderByCreatedAtDesc(Long pinId);
 
     Optional<Comment> findByCommentIdAndPinPinId(Long commentId, Long pinId);
+
+    @Query("""
+            select c
+            from Comment c
+            join fetch c.user
+            join fetch c.pin
+            where c.commentId = :commentId
+            """)
+    Optional<Comment> findByIdWithUserAndPin(@Param("commentId") Long commentId);
 }

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/CommentCommandService.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/CommentCommandService.java
@@ -6,7 +6,7 @@ import issueissyu.backend.domain.pin.dto.res.CommentResDTO;
 public interface CommentCommandService {
     CommentResDTO createComment(Long pinId, String uid, CommentReqDTO request);
 
-    CommentResDTO updateComment(Long pinId, Long commentId, String uid, CommentReqDTO request);
+    CommentResDTO updateComment(Long commentId, String uid, CommentReqDTO request);
 
-    void deleteComment(Long pinId, Long commentId, String uid);
+    void deleteComment(Long commentId, String uid);
 }

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/CommentCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/CommentCommandServiceImpl.java
@@ -54,6 +54,7 @@ public class CommentCommandServiceImpl implements CommentCommandService {
         }
 
         comment.updateContent(request.getCommentContent());
+        commentRepository.flush();
         communicationPinActivityMarker.markReactionOrComment(comment.getPin().getPinId());
         return CommentConverter.toCommentResDTO(comment, uid);
     }

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/CommentCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/CommentCommandServiceImpl.java
@@ -46,7 +46,7 @@ public class CommentCommandServiceImpl implements CommentCommandService {
 
     @Override
     public CommentResDTO updateComment(Long commentId, String uid, CommentReqDTO request) {
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findByIdWithUserAndPin(commentId)
                 .orElseThrow(() -> PinException.of(PinErrorCode.COMMENT_NOT_FOUND));
 
         if (!comment.getUser().getUid().equals(uid)) {
@@ -60,7 +60,7 @@ public class CommentCommandServiceImpl implements CommentCommandService {
 
     @Override
     public void deleteComment(Long commentId, String uid) {
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findByIdWithUserAndPin(commentId)
                 .orElseThrow(() -> PinException.of(PinErrorCode.COMMENT_NOT_FOUND));
 
         if (!comment.getUser().getUid().equals(uid)) {

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/CommentCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/CommentCommandServiceImpl.java
@@ -9,7 +9,6 @@ import issueissyu.backend.domain.pin.exception.PinException;
 import issueissyu.backend.domain.pin.exception.code.PinErrorCode;
 import issueissyu.backend.domain.pin.repository.CommentRepository;
 import issueissyu.backend.domain.pin.repository.PinRepository;
-import issueissyu.backend.domain.pin.service.command.CommunicationPinActivityMarker;
 import issueissyu.backend.domain.user.entity.User;
 import issueissyu.backend.domain.user.repository.UserRepository;
 import issueissyu.backend.global.api.code.GeneralErrorCode;
@@ -46,8 +45,8 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     }
 
     @Override
-    public CommentResDTO updateComment(Long pinId, Long commentId, String uid, CommentReqDTO request) {
-        Comment comment = commentRepository.findByCommentIdAndPinPinId(commentId, pinId)
+    public CommentResDTO updateComment(Long commentId, String uid, CommentReqDTO request) {
+        Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> PinException.of(PinErrorCode.COMMENT_NOT_FOUND));
 
         if (!comment.getUser().getUid().equals(uid)) {
@@ -55,13 +54,13 @@ public class CommentCommandServiceImpl implements CommentCommandService {
         }
 
         comment.updateContent(request.getCommentContent());
-        communicationPinActivityMarker.markReactionOrComment(pinId);
+        communicationPinActivityMarker.markReactionOrComment(comment.getPin().getPinId());
         return CommentConverter.toCommentResDTO(comment, uid);
     }
 
     @Override
-    public void deleteComment(Long pinId, Long commentId, String uid) {
-        Comment comment = commentRepository.findByCommentIdAndPinPinId(commentId, pinId)
+    public void deleteComment(Long commentId, String uid) {
+        Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> PinException.of(PinErrorCode.COMMENT_NOT_FOUND));
 
         if (!comment.getUser().getUid().equals(uid)) {


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #50 

## ✨ 작업 개요
> 댓글 수정/삭제 API 의 필요 없는 pinId 요청 파라미터를 제거하였습니다
> 수정 시 edited를 true로 바꾸어 댓글 목록 조회 시 수정 여부를 포함하여 응답하도록 하였습니다.
> ( ERD 에  is_edited 추가 완료 ! )
> 현재 영속성 컨텍스트 관련하여 수정 시 DB에 반영이 안되는 버그가 있습니다. 이는 버그 이슈로 추가한 다음 담당자와 해결 방법을 이야기한 후 추가 수정하겠습니다.! 

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
<img width="1808" height="582" alt="image" src="https://github.com/user-attachments/assets/19ac3c46-6442-4ec0-a8fd-f2a5d4dbb950" />

## 🧐 집중 리뷰 요청