### PR TITLE
[REFACTOR] adm_code/location 매핑 정리 및 시군구 조회·주소 API 추가

### DIFF
--- a/src/main/java/issueissyu/backend/domain/location/controller/LocationController.java
+++ b/src/main/java/issueissyu/backend/domain/location/controller/LocationController.java
@@ -43,6 +43,16 @@ public class LocationController {
         return ApiResponse.onSuccess(LocationSuccessCode.LOCATION_USER_CERT_SUCCESS, result);
     }
 
+    @Operation(summary = "좌표 → 도로명 주소 조회")
+    @GetMapping("/address")
+    public ApiResponse<UserLocationResDTO> getRoadAddress(
+            @RequestParam("lat") double lat,
+            @RequestParam("lng") double lng
+    ) {
+        UserLocationResDTO result = locationService.getRoadAddress(toPoint(lat, lng));
+        return ApiResponse.onSuccess(LocationSuccessCode.LOCATION_ROAD_ADDRESS_SUCCESS, result);
+    }
+
     @Operation(summary = "핀 생성 가능 여부 확인")
     @GetMapping("/pin/available")
     public ApiResponse<UserLocationResDTO> isUserCanPostPin(

--- a/src/main/java/issueissyu/backend/domain/location/dto/res/UserLocationCertResDto.java
+++ b/src/main/java/issueissyu/backend/domain/location/dto/res/UserLocationCertResDto.java
@@ -13,7 +13,7 @@ public class UserLocationCertResDto {
 
     public static UserLocationCertResDto from(Location location) {
         return new UserLocationCertResDto(
-                location.getAdmCode()
+                location.getRegion()
         );
     }
 

--- a/src/main/java/issueissyu/backend/domain/location/entity/Location.java
+++ b/src/main/java/issueissyu/backend/domain/location/entity/Location.java
@@ -25,9 +25,9 @@ public class Location {
     @Column(name = "location_id")
     private Long locationId;
 
-    @Column(name = "location", nullable = false, length = 10)
-    private String region;
-
-    @Column(name = "adm_code", nullable = false, length = 50)
+    @Column(name = "adm_code", nullable = false, unique = true, length = 10)
     private String admCode;
+
+    @Column(name = "location", nullable = false, length = 50)
+    private String region;
 }

--- a/src/main/java/issueissyu/backend/domain/location/exception/code/LocationSuccessCode.java
+++ b/src/main/java/issueissyu/backend/domain/location/exception/code/LocationSuccessCode.java
@@ -12,7 +12,8 @@ public enum LocationSuccessCode implements BaseSuccessCode {
     LOCATION_GEOCODE_SUCCESS(HttpStatus.OK, "LOCATION_200_2", "지오코딩에 성공했습니다."),
     LOCATION_USER_GET_SUCCESS(HttpStatus.OK, "LOCATION_200_3", "사용자 위치 조회에 성공했습니다."),
     LOCATION_USER_CERT_SUCCESS(HttpStatus.OK, "LOCATION_200_4", "사용자 위치 인증에 성공했습니다."),
-    LOCATION_PIN_CREATION_CHECK_SUCCESS(HttpStatus.OK, "LOCATION_200_5", "핀 생성 가능 여부 확인에 성공했습니다.");
+    LOCATION_PIN_CREATION_CHECK_SUCCESS(HttpStatus.OK, "LOCATION_200_5", "핀 생성 가능 여부 확인에 성공했습니다."),
+    LOCATION_ROAD_ADDRESS_SUCCESS(HttpStatus.OK, "LOCATION_200_6", "도로명 주소 조회에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/issueissyu/backend/domain/location/repository/LocationRepository.java
+++ b/src/main/java/issueissyu/backend/domain/location/repository/LocationRepository.java
@@ -3,14 +3,14 @@ package issueissyu.backend.domain.location.repository;
 import issueissyu.backend.domain.location.entity.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import java.util.Optional;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
 
     /**
-     * {@code location} 컬럼(법정동코드 문자열) 앞 5자리가 시군구와 일치하는 행을 조회합니다.
+     * {@code adm_code} 컬럼에서 시군구 코드(앞 5자리) + {@code "00000"} 으로 구성된 정확한 코드와 일치하는 행을 조회합니다.
      *
-     * @param prefix 법정동코드 앞 5자리 (예: 네이버 {@code legalDistrictCode}의 앞 5글자)
+     * @param sigunguCode 법정동코드 앞 5자리 + "00000" (예: "1168000000")
      */
-    List<Location> findAllByRegionStartingWith(String prefix);
+    Optional<Location> findByAdmCode(String sigunguCode);
 }

--- a/src/main/java/issueissyu/backend/domain/location/service/LocationService.java
+++ b/src/main/java/issueissyu/backend/domain/location/service/LocationService.java
@@ -51,6 +51,12 @@ public class LocationService {
     }
 
     @Transactional(readOnly = true)
+    public UserLocationResDTO getRoadAddress(PGpoint point) {
+        String address = naverMapService.resolveRoadAddressOf(point);
+        return new UserLocationResDTO(address);
+    }
+
+    @Transactional(readOnly = true)
     public UserLocationResDTO isUserCanPostPin(String userId, PGpoint userPoint, PGpoint pinPoint){
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> GeneralException.of(GeneralErrorCode.USER_NOT_FOUND));
@@ -62,7 +68,7 @@ public class LocationService {
         double distanceInMeters = calDist(userPoint.y, userPoint.x, pinPoint.y, pinPoint.x);
         NaverReverseGeocodeCodeAddressResDTO resolved = naverMapService.resolveLegalDistrictCodeAndAddress(pinPoint);
         String pinSigunguPrefix = extractSigunguPrefix(resolved.legalDistrictCode());
-        String userSigunguPrefix = extractSigunguPrefix(user.getUserLocation().getLocation().getRegion());
+        String userSigunguPrefix = extractSigunguPrefix(user.getUserLocation().getLocation().getAdmCode());
 
         if(distanceInMeters <= 100){
             return new UserLocationResDTO(resolved.address());
@@ -83,9 +89,8 @@ public class LocationService {
     }
 
     private Location findLocationByLegalDistrictCode(String legalDistrictCode) {
-        String sigunguPrefix = extractSigunguPrefix(legalDistrictCode);
-        return locationRepository.findAllByRegionStartingWith(sigunguPrefix).stream()
-                .findFirst()
+        String sigunguCode = buildSigunguCode(legalDistrictCode);
+        return locationRepository.findByAdmCode(sigunguCode)
                 .orElseThrow(() -> LocationException.of(LocationErrorCode.LOCATION_LEGAL_DISTRICT_CODE_NOT_FOUND));
     }
 
@@ -94,5 +99,9 @@ public class LocationService {
             throw LocationException.of(LocationErrorCode.LOCATION_LEGAL_DISTRICT_CODE_NOT_FOUND);
         }
         return legalDistrictCode.substring(0, 5);
+    }
+
+    private String buildSigunguCode(String legalDistrictCode) {
+        return extractSigunguPrefix(legalDistrictCode) + "00000";
     }
 }

--- a/src/main/java/issueissyu/backend/domain/map/dto/res/MapPinView.java
+++ b/src/main/java/issueissyu/backend/domain/map/dto/res/MapPinView.java
@@ -8,5 +8,5 @@ public interface MapPinView {
     Double getLat();      // ST_Y(pin_point) → 위도
     Double getLng();      // ST_X(pin_point) → 경도
     String getDetailAddress();
-    String getRegion();   // location.location 컬럼 (법정동코드 10자리 문자열)
+    String getRegion();   // location.location 컬럼 (법정동 주소 문자열)
 }


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #92 

## ✨ 작업 개요
- 법정동 코드는 adm_code, 표시용 주소는 location 컬럼과 매핑
- 시군구 단위 조회를 prefix 검색 대신 앞 5자리 + "00000" 정확 일치(findByAdmCode)로 변경
- GET /api/location/address 로 좌표 기준 도로명 주소(역지오코딩) 조회 API 추가
- MapPinView 주석 등 관련 DTO/성공 코드 보완

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
<img width="1531" height="1179" alt="image" src="https://github.com/user-attachments/assets/7e7ed7e2-8478-405c-880c-321adb5356b4" />
<img width="1624" height="1381" alt="image" src="https://github.com/user-attachments/assets/b51d5267-2533-4418-96f3-7e84b013aa9d" />

## 🧐 집중 리뷰 요청

배포/테스트하기전 해당 데이터 베이스에 접근하셔서 필수로 해당 sql문을 실행시켜 location 테이블 변수명 변경 및 unique옵션을 꼭 켜주세요!!!!!!!!!!!!!!
```shell
ALTER TABLE location RENAME COLUMN location TO location_tmp;
ALTER TABLE location RENAME COLUMN adm_code TO location;
ALTER TABLE location RENAME COLUMN location_tmp TO adm_code;
ALTER TABLE location ADD CONSTRAINT uq_location_adm_code UNIQUE (adm_code);
``` 