### PR TITLE
[FEAT] 커뮤니티 게시물 상세 조회 응답에 사용자 기반 기타 상태값 추가

### DIFF
--- a/src/main/java/issueissyu/backend/domain/community/controller/CommunityController.java
+++ b/src/main/java/issueissyu/backend/domain/community/controller/CommunityController.java
@@ -52,8 +52,10 @@ public class CommunityController {
 
     @Operation(summary = "커뮤니티 게시물 상세 조회", description = "연결된 핀 카드 정보와 본문(content)을 반환합니다. 조회 시 조회수가 증가합니다.")
     @GetMapping("/{communityId}")
-    public ApiResponse<CommunityDetailResDTO> getDetail(@PathVariable Long communityId) {
-        CommunityDetailResDTO result = communityQueryService.getCommunityDetail(communityId);
+    public ApiResponse<CommunityDetailResDTO> getDetail(
+            @PathVariable Long communityId,
+            @AuthenticationPrincipal String uid) {
+        CommunityDetailResDTO result = communityQueryService.getCommunityDetail(communityId, uid);
         return ApiResponse.onSuccess(CommunitySuccessCode.COMMUNITY_DETAIL_200, result);
     }
 

--- a/src/main/java/issueissyu/backend/domain/community/dto/res/CommunityDetailResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/community/dto/res/CommunityDetailResDTO.java
@@ -8,6 +8,9 @@ public record CommunityDetailResDTO(
         String content,
         List<String> pinImageUrls,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        boolean isReported,
+        Boolean isPetitioned,
+        Boolean isProblemSolver
 ) {
 }

--- a/src/main/java/issueissyu/backend/domain/community/dto/res/CommunityDetailResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/community/dto/res/CommunityDetailResDTO.java
@@ -11,6 +11,7 @@ public record CommunityDetailResDTO(
         LocalDateTime updatedAt,
         Boolean isReported,
         Boolean isPetitioned,
-        Boolean isProblemSolver
+        Boolean isProblemSolver,
+        boolean isMine
 ) {
 }

--- a/src/main/java/issueissyu/backend/domain/community/dto/res/CommunityDetailResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/community/dto/res/CommunityDetailResDTO.java
@@ -9,7 +9,7 @@ public record CommunityDetailResDTO(
         List<String> pinImageUrls,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        boolean isReported,
+        Boolean isReported,
         Boolean isPetitioned,
         Boolean isProblemSolver
 ) {

--- a/src/main/java/issueissyu/backend/domain/community/entity/Community.java
+++ b/src/main/java/issueissyu/backend/domain/community/entity/Community.java
@@ -54,15 +54,8 @@ public class Community extends BaseEntity {
     @Column(length = 255)
     private String content;
 
-    @Column(name = "view_count", nullable = false)
-    private int viewCount;
-
     @Builder.Default
     @OneToMany(mappedBy = "community", fetch = FetchType.LAZY)
     @ToString.Exclude
     private List<CardnewsImageS3> cardnewsImages = new ArrayList<>();
-
-    public void incrementViewCount() {
-        this.viewCount++;
-    }
 }

--- a/src/main/java/issueissyu/backend/domain/community/service/query/CommunityQueryService.java
+++ b/src/main/java/issueissyu/backend/domain/community/service/query/CommunityQueryService.java
@@ -7,5 +7,5 @@ import issueissyu.backend.domain.community.enums.CommunityTab;
 public interface CommunityQueryService {
     CommunityCursorPageResDTO getCommunityFeed(CommunityTab tab, String region, String cursor, int size);
 
-    CommunityDetailResDTO getCommunityDetail(Long communityId);
+    CommunityDetailResDTO getCommunityDetail(Long communityId, String uid);
 }

--- a/src/main/java/issueissyu/backend/domain/community/service/query/CommunityQueryServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/community/service/query/CommunityQueryServiceImpl.java
@@ -42,6 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -128,6 +129,8 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
                 ? problemSolverRepository.existsByIssuePin_Pin_PinIdAndUser_Uid(pinId, uid)
                 : null;
 
+        boolean isMine = Objects.equals(pin.getUser().getUid(), uid);
+
         return new CommunityDetailResDTO(
                 item,
                 detailContent,
@@ -136,7 +139,8 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
                 community.getUpdatedAt(),
                 isReported,
                 isPetitioned,
-                isProblemSolver);
+                isProblemSolver,
+                isMine);
     }
 
     // 상세 조회용 DTO 분기 (ISSUE는 추가 데이터 포함, 나머지는 피드 DTO 재사용)

--- a/src/main/java/issueissyu/backend/domain/community/service/query/CommunityQueryServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/community/service/query/CommunityQueryServiceImpl.java
@@ -29,6 +29,9 @@ import issueissyu.backend.domain.pin.repository.DeclarationRepository;
 import issueissyu.backend.domain.pin.repository.EventPinRepository;
 import issueissyu.backend.domain.pin.repository.PinImageRepository;
 import issueissyu.backend.domain.pin.repository.StoreImageRepository;
+import issueissyu.backend.domain.user.repository.UserRepository;
+import issueissyu.backend.global.api.code.GeneralErrorCode;
+import issueissyu.backend.global.exception.GeneralException;
 import issueissyu.backend.domain.user.service.query.UserProfileImageQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -62,6 +65,7 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
     private final IssuePetitionRepository issuePetitionRepository;
     private final ProblemSolverRepository problemSolverRepository;
     private final DeclarationRepository declarationRepository;
+    private final UserRepository userRepository;
     private final UserProfileImageQueryService userProfileImageQueryService;
 
     @Override
@@ -89,11 +93,13 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
     @Override
     @Transactional(readOnly = false)
     public CommunityDetailResDTO getCommunityDetail(Long communityId, String uid) {
+        userRepository.findById(uid)
+                .orElseThrow(() -> GeneralException.of(GeneralErrorCode.USER_NOT_FOUND));
+
         Community community = communityRepository.findDetailById(communityId)
                 .orElseThrow(() -> CommunityException.of(CommunityErrorCode.COMMUNITY_404_1));
-        community.incrementViewCount();
-
         Pin pin = community.getPin();
+        pin.incrementViewCount();
         Long pinId = pin.getPinId();
         CommunityType type = community.getCommunityType();
 
@@ -114,7 +120,7 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
                 ? declarationRepository.existsByPin_PinIdAndUser_Uid(pinId, uid)
                 : null;
 
-        // 청원·지금가요 여부 - ISSUE 
+        // 청원·지금가요 여부 - ISSUE 타입만
         Boolean isPetitioned = type == CommunityType.ISSUE
                 ? issuePetitionRepository.existsByIssuePin_Pin_PinIdAndUser_Uid(pinId, uid)
                 : null;
@@ -156,7 +162,7 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
                 pin.getUser().getNickname(),
                 userProfileImageQueryService.findUrlByUserUid(pin.getUser().getUid()).orElse(null),
                 resolveAddress(pin.getPinId()),
-                community.getViewCount(),
+                pin.getViewCount(),
                 pin.getLikeCount(),
                 issuePin != null ? issuePin.getIssuePinState().name() : null);
     }
@@ -200,7 +206,7 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
                 pin.getUser().getNickname(),
                 userProfileImageQueryService.findUrlByUserUid(pin.getUser().getUid()).orElse(null),
                 resolveAddress(pin.getPinId()),
-                community.getViewCount(),
+                pin.getViewCount(),
                 pin.getLikeCount());
     }
 
@@ -220,7 +226,7 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
                 resolveAddress(pin.getPinId()),
                 eventPin.map(EventPin::getEventStartTime).orElse(null),
                 eventPin.map(EventPin::getEventEndTime).orElse(null),
-                community.getViewCount(),
+                pin.getViewCount(),
                 pin.getLikeCount());
     }
 
@@ -235,7 +241,7 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
                 pin.getUser().getNickname(),
                 userProfileImageQueryService.findUrlByUserUid(pin.getUser().getUid()).orElse(null),
                 resolveAddress(pin.getPinId()),
-                community.getViewCount(),
+                pin.getViewCount(),
                 pin.getLikeCount());
     }
 

--- a/src/main/java/issueissyu/backend/domain/community/service/query/CommunityQueryServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/community/service/query/CommunityQueryServiceImpl.java
@@ -107,8 +107,12 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
         // STORE는 content가 피드 item 안에 포함되므로 래퍼의 content는 null
         String detailContent = type == CommunityType.STORE ? null : community.getContent();
 
-        // 신고 여부 - 모든 타입에 공통
-        boolean isReported = declarationRepository.existsByPin_PinIdAndUser_Uid(pinId, uid);
+        // 신고 여부 - ISSUE, COMMUNICATION, STORE 타입만
+        Boolean isReported = (type == CommunityType.ISSUE
+                        || type == CommunityType.COMMUNICATION
+                        || type == CommunityType.STORE)
+                ? declarationRepository.existsByPin_PinIdAndUser_Uid(pinId, uid)
+                : null;
 
         // 청원·지금가요 여부 - ISSUE 
         Boolean isPetitioned = type == CommunityType.ISSUE

--- a/src/main/java/issueissyu/backend/domain/community/service/query/CommunityQueryServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/community/service/query/CommunityQueryServiceImpl.java
@@ -15,7 +15,9 @@ import issueissyu.backend.domain.community.exception.CommunityException;
 import issueissyu.backend.domain.community.exception.code.CommunityErrorCode;
 import issueissyu.backend.domain.community.repository.CommunityRepository;
 import issueissyu.backend.domain.issue.entity.IssuePin;
+import issueissyu.backend.domain.issue.repository.IssuePetitionRepository;
 import issueissyu.backend.domain.issue.repository.IssuePinRepository;
+import issueissyu.backend.domain.issue.repository.ProblemSolverRepository;
 import issueissyu.backend.domain.location.entity.PinLocation;
 import issueissyu.backend.domain.location.repository.LocationRepository;
 import issueissyu.backend.domain.location.repository.PinLocationRepository;
@@ -23,6 +25,7 @@ import issueissyu.backend.domain.pin.entity.EventPin;
 import issueissyu.backend.domain.pin.entity.Pin;
 import issueissyu.backend.domain.pin.entity.PinImage;
 import issueissyu.backend.domain.pin.entity.StoreImage;
+import issueissyu.backend.domain.pin.repository.DeclarationRepository;
 import issueissyu.backend.domain.pin.repository.EventPinRepository;
 import issueissyu.backend.domain.pin.repository.PinImageRepository;
 import issueissyu.backend.domain.pin.repository.StoreImageRepository;
@@ -56,6 +59,9 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
     private final StoreImageRepository storeImageRepository;
     private final PinImageRepository pinImageRepository;
     private final IssuePinRepository issuePinRepository;
+    private final IssuePetitionRepository issuePetitionRepository;
+    private final ProblemSolverRepository problemSolverRepository;
+    private final DeclarationRepository declarationRepository;
     private final UserProfileImageQueryService userProfileImageQueryService;
 
     @Override
@@ -82,29 +88,45 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
 
     @Override
     @Transactional(readOnly = false)
-    public CommunityDetailResDTO getCommunityDetail(Long communityId) {
+    public CommunityDetailResDTO getCommunityDetail(Long communityId, String uid) {
         Community community = communityRepository.findDetailById(communityId)
                 .orElseThrow(() -> CommunityException.of(CommunityErrorCode.COMMUNITY_404_1));
         community.incrementViewCount();
 
+        Pin pin = community.getPin();
+        Long pinId = pin.getPinId();
+        CommunityType type = community.getCommunityType();
+
         CommunityDetailItemResDTO item = toDetailItem(community);
         List<String> pinImageUrls = pinImageRepository
-                .findByPin_PinIdOrderByPinImageIdAsc(community.getPin().getPinId())
+                .findByPin_PinIdOrderByPinImageIdAsc(pinId)
                 .stream()
                 .map(PinImage::getPinS3Url)
                 .toList();
 
         // STORE는 content가 피드 item 안에 포함되므로 래퍼의 content는 null
-        String detailContent = community.getCommunityType() == CommunityType.STORE
-                ? null
-                : community.getContent();
+        String detailContent = type == CommunityType.STORE ? null : community.getContent();
+
+        // 신고 여부 - 모든 타입에 공통
+        boolean isReported = declarationRepository.existsByPin_PinIdAndUser_Uid(pinId, uid);
+
+        // 청원·지금가요 여부 - ISSUE 
+        Boolean isPetitioned = type == CommunityType.ISSUE
+                ? issuePetitionRepository.existsByIssuePin_Pin_PinIdAndUser_Uid(pinId, uid)
+                : null;
+        Boolean isProblemSolver = type == CommunityType.ISSUE
+                ? problemSolverRepository.existsByIssuePin_Pin_PinIdAndUser_Uid(pinId, uid)
+                : null;
 
         return new CommunityDetailResDTO(
                 item,
                 detailContent,
                 pinImageUrls,
                 community.getCreatedAt(),
-                community.getUpdatedAt());
+                community.getUpdatedAt(),
+                isReported,
+                isPetitioned,
+                isProblemSolver);
     }
 
     // 상세 조회용 DTO 분기 (ISSUE는 추가 데이터 포함, 나머지는 피드 DTO 재사용)

--- a/src/main/java/issueissyu/backend/domain/pin/entity/Pin.java
+++ b/src/main/java/issueissyu/backend/domain/pin/entity/Pin.java
@@ -33,6 +33,10 @@ public class Pin extends BaseEntity {
     @Column(name = "like_count", nullable = false)
     private int likeCount = 0;
 
+    @Builder.Default
+    @Column(name = "view_count", nullable = false)
+    private int viewCount = 0;
+
     @Column(name = "pin_title", nullable = false, length = 100)
     private String pinTitle;
 
@@ -70,5 +74,9 @@ public class Pin extends BaseEntity {
 
     public void incrementLikeCount() {
         this.likeCount++;
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
     }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #100 

## ✨ 작업 개요
> 커뮤니티 게시물 상세 조회 API(GET /api/communities/{communityId}) 응답에 현재 로그인 유저 기준의 상태값 3개과 본인 게시물인지 여부를 추가하였습니다.

isReported : 현재 유저가 해당 게시물을 신고했는지 여부 (ISSUE, COMMUNITY, STORE 만, 나머지 null)
isPetitioned : 현재 유저가 해당 이슈에 청원했는지 여부 (ISSUE 타입만, 나머지 null)
isProblemSolver : 현재 유저가 지금가요(시민해결사)에 참여했는지 여부 (ISSUE 타입만, 나머지 null)
isMine : 현재 유저가 게시물 작성자인지 아닌지 여부

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
<img width="2530" height="822" alt="image" src="https://github.com/user-attachments/assets/c7728a4e-7057-432f-b2b8-412dd5ca6450" />

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
로컬 디비는 아래의 쿼리문으로 수정하였습니다.

```
BEGIN;

-- 1. pin 테이블에 view_count 추가
ALTER TABLE pin
    ADD COLUMN IF NOT EXISTS view_count BIGINT NOT NULL DEFAULT 0;

-- 2. 기존 community.view_count 값이 있었다면 pin으로 옮기기
UPDATE pin p
SET view_count = COALESCE(c.view_count, 0)
FROM community c
WHERE c.pin_id = p.pin_id;

-- 3. community 테이블의 view_count 제거
ALTER TABLE community
    DROP COLUMN IF EXISTS view_count;

COMMIT;
```