### PR TITLE
[FEAT] 아이디 중복 확인 API 구현 및 비밀번호 조건 충족 여부 판단 삭제

### DIFF
--- a/src/main/java/issueissyu/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/issueissyu/backend/domain/auth/controller/AuthController.java
@@ -189,7 +189,7 @@ public class AuthController {
     }
 
     @Operation(summary = "닉네임 중복 확인", description = "입력한 닉네임의 형식 및 중복 여부를 확인합니다.")
-    @GetMapping("/api/auth/nickname/{nickname}/check")
+    @GetMapping("/api/auth/check/nickname/{nickname}")
     public ApiResponse<NicknameCheckResDTO> checkNickname(
             @PathVariable String nickname
     ) {
@@ -214,20 +214,11 @@ public class AuthController {
     }
 
     @Operation(
-            summary = "아이디 중복 확인",
-            description =
-                    "user.user_name 컬럼 기준으로 중복 여부를 확인합니다. 아이디는 공백 제거 후 1~100자여야 합니다. "
-                            + "Query userName을 보낸 경우 Path username과 동일해야 합니다. Authorization(Bearer) 필요.")
-    @GetMapping("/api/auth/{username}/check")
-    public ApiResponse<UsernameCheckResDTO> checkUsername(
-            @PathVariable String username,
-            @RequestParam(value = "userName", required = false) String userNameQuery) {
+            summary = "아이디 중복 확인")
+    @GetMapping("/api/auth/check/username/{username}")
+    public ApiResponse<UsernameCheckResDTO> checkUsername(@PathVariable String username) {
         UsernameCheckResDTO unavailable =
                 UsernameCheckResDTO.builder().isAvailableUsername(false).build();
-
-        if (userNameQuery != null && !username.trim().equals(userNameQuery.trim())) {
-            return ApiResponse.onFailure(AuthErrorCode.USERNAME_400, unavailable);
-        }
 
         if (!authService.isValidUsernameLength(username)) {
             return ApiResponse.onFailure(AuthErrorCode.USERNAME_400, unavailable);

--- a/src/main/java/issueissyu/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/issueissyu/backend/domain/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import issueissyu.backend.domain.auth.dto.res.LocalSignupResDTO;
 import issueissyu.backend.domain.auth.dto.res.LoginLinkResDTO;
 import issueissyu.backend.domain.auth.dto.res.NaverAppLoginResDTO;
 import issueissyu.backend.domain.auth.dto.res.NicknameCheckResDTO;
+import issueissyu.backend.domain.auth.dto.res.UsernameCheckResDTO;
 import issueissyu.backend.domain.auth.dto.res.OnboardingResDTO;
 import issueissyu.backend.domain.auth.service.LocalLoginService;
 import issueissyu.backend.domain.auth.service.LocalSignupService;
@@ -188,7 +189,7 @@ public class AuthController {
     }
 
     @Operation(summary = "닉네임 중복 확인", description = "입력한 닉네임의 형식 및 중복 여부를 확인합니다.")
-    @GetMapping("/api/auth/{nickname}/check")
+    @GetMapping("/api/auth/nickname/{nickname}/check")
     public ApiResponse<NicknameCheckResDTO> checkNickname(
             @PathVariable String nickname
     ) {
@@ -210,6 +211,40 @@ public class AuthController {
                 .build();
 
         return ApiResponse.onSuccess(AuthSuccessCode.NICKNAME_200, available);
+    }
+
+    @Operation(
+            summary = "아이디 중복 확인",
+            description =
+                    "user.user_name 컬럼 기준으로 중복 여부를 확인합니다. 아이디는 공백 제거 후 1~100자여야 합니다. "
+                            + "Query userName을 보낸 경우 Path username과 동일해야 합니다. Authorization(Bearer) 필요.")
+    @GetMapping("/api/auth/{username}/check")
+    public ApiResponse<UsernameCheckResDTO> checkUsername(
+            @PathVariable String username,
+            @RequestParam(value = "userName", required = false) String userNameQuery) {
+        UsernameCheckResDTO unavailable =
+                UsernameCheckResDTO.builder().isAvailableUsername(false).build();
+
+        if (userNameQuery != null && !username.trim().equals(userNameQuery.trim())) {
+            return ApiResponse.onFailure(AuthErrorCode.USERNAME_400, unavailable);
+        }
+
+        if (!authService.isValidUsernameLength(username)) {
+            return ApiResponse.onFailure(AuthErrorCode.USERNAME_400, unavailable);
+        }
+
+        if (authService.isUsernameDuplicated(username)) {
+            return ApiResponse.onFailure(AuthErrorCode.USERNAME_409, unavailable);
+        }
+
+        String trimmed = username.trim();
+        UsernameCheckResDTO available =
+                UsernameCheckResDTO.builder()
+                        .isAvailableUsername(true)
+                        .userName(trimmed)
+                        .build();
+
+        return ApiResponse.onSuccess(AuthSuccessCode.USERNAME_200, available);
     }
 
     @Operation(summary = "회원탈퇴", description = "인증된 사용자의 연관 데이터(pin·댓글·알림 등)를 정리한 뒤 Redis 토큰·OAuth·User 레코드를 삭제합니다.")

--- a/src/main/java/issueissyu/backend/domain/auth/dto/req/LocalSignupReqDTO.java
+++ b/src/main/java/issueissyu/backend/domain/auth/dto/req/LocalSignupReqDTO.java
@@ -4,7 +4,6 @@ package issueissyu.backend.domain.auth.dto.req;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,9 +19,5 @@ public class LocalSignupReqDTO {
     @JsonProperty("password")
     @Schema(example = "string")
     @NotBlank(message = "비밀번호를 입력해주세요.")
-    @Pattern(
-            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,20}$",
-            message = "비밀번호는 8~20자이며 영문, 숫자, 특수문자를 각각 1개 이상 포함해야 합니다."
-    )
     private String password;
 }

--- a/src/main/java/issueissyu/backend/domain/auth/dto/res/UsernameCheckResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/auth/dto/res/UsernameCheckResDTO.java
@@ -1,0 +1,23 @@
+package issueissyu.backend.domain.auth.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UsernameCheckResDTO {
+
+    @Getter(AccessLevel.NONE)
+    private final boolean isAvailableUsername;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final String userName;
+
+    @JsonProperty("isAvailableUsername")
+    public boolean isAvailableUsername() {
+        return isAvailableUsername;
+    }
+}

--- a/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
@@ -20,6 +20,8 @@ public enum AuthErrorCode implements BaseErrorCode {
     LOCAL_LOGIN_401(HttpStatus.UNAUTHORIZED, "LOCAL_LOGIN_401", "아이디 또는 비밀번호가 올바르지 않습니다."),
     NICKNAME_400(HttpStatus.BAD_REQUEST, "NICKNAME_400", "닉네임은 15자 이내의 영문, 숫자, 한글만 사용 가능합니다."),
     NICKNAME_409(HttpStatus.CONFLICT, "NICKNAME_409", "이미 사용 중인 닉네임입니다."),
+    USERNAME_400(HttpStatus.BAD_REQUEST, "USERNAME_400", "아이디는 100자 이내이어야 합니다."),
+    USERNAME_409(HttpStatus.CONFLICT, "USERNAME_409", "이미 사용 중인 아이디 입니다."),
     TERM_400(HttpStatus.BAD_REQUEST, "TERM_400", "필수 약관(SERVICE, PRIVACY)에 모두 동의해야 합니다."),
 
     // 전화번호 인증

--- a/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthSuccessCode.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthSuccessCode.java
@@ -18,6 +18,7 @@ public enum AuthSuccessCode implements BaseSuccessCode {
     LOCAL_LOGIN_200_1(HttpStatus.OK, "LOCAL_LOGIN_200_1", "처음으로 로컬 로그인에 성공했습니다."),
     LOCAL_LOGIN_200_2(HttpStatus.OK, "LOCAL_LOGIN_200_2", "로컬 로그인에 성공했습니다."),
     NICKNAME_200(HttpStatus.OK, "NICKNAME_200", "사용 가능한 닉네임입니다."),
+    USERNAME_200(HttpStatus.OK, "USERNAME_200", "사용 가능한 아이디 입니다."),
     TERM_200(HttpStatus.OK, "TERM_200", "약관 동의에 성공했습니다."),
 
     // 전화번호 인증

--- a/src/main/java/issueissyu/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/AuthService.java
@@ -165,4 +165,16 @@ public class AuthService {
     public boolean isNicknameDuplicated(String nickname) {
         return userRepository.existsByNickname(nickname);
     }
+
+    public boolean isValidUsernameLength(String userName) {
+        if (userName == null) {
+            return false;
+        }
+        String t = userName.trim();
+        return !t.isEmpty() && t.length() <= 100;
+    }
+
+    public boolean isUsernameDuplicated(String userName) {
+        return userRepository.existsByUserName(userName.trim());
+    }
 }

--- a/src/main/java/issueissyu/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/issueissyu/backend/domain/user/repository/UserRepository.java
@@ -8,6 +8,9 @@ import java.util.Optional;
 
 
 public interface UserRepository extends JpaRepository<User, String> {
+
+    boolean existsByUserName(String userName);
+
     boolean existsByNickname(String nickname);
     boolean existsByPhone(String phone);
     Optional<User> findByPhone(String phone);


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #124

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.

프론트 요청으로 아이디 중복 확인 API 구현합니다.
비밀번호 검증 (비밀번호는 8~20자, 영문·숫자·특수문자 각 1개 이상) 조건이 프론트에서 지속적으로 변경됨에 따라 빠른 개발을 위해 백엔드 검증 로직을 삭제합니다.

- GET /api/auth/{username}/check -> 아이디 중복 체크 API
- POST /auth/signup/local -> 비밀번호 조건 삭제

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
<img width="1582" height="507" alt="image" src="https://github.com/user-attachments/assets/9ae36545-1c46-42d6-94a6-a6e28522ed51" />

<img width="1581" height="496" alt="image" src="https://github.com/user-attachments/assets/b923b028-764c-4b1b-928e-9f506873200a" />


## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.