### PR TITLE
[BUG] CI 내 apt 기반 PostgreSQL/Redis smoke 단계 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # PR / push 시 Spring Boot 백엔드 통합 CI
-# 인프라 스모크(Postgres / Redis / S3) → bootJar → JAR 기동 후 /health 200 확인
+# 서비스 컨테이너(Postgres / Redis) → S3 smoke → bootJar → JAR 기동 후 /health 200 확인
 
 name: IssueIssyu Backend CI
 
@@ -68,7 +68,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # GitHub → Settings → Secrets → CI_ENV (파일 상단 주석의 필수 키 참고)
+      # GitHub → Settings → Secrets → CI_ENV
       - name: Create .env from secret (CI_ENV)
         run: |
           if [ -z "${{ secrets.CI_ENV }}" ]; then
@@ -78,7 +78,7 @@ jobs:
           printf '%s' "${{ secrets.CI_ENV }}" > .env
           chmod 600 .env
 
-      # CI 서비스(Postgres/Redis) 주소로 덮어쓰기 
+      # CI 서비스(Postgres/Redis) 주소로 덮어쓰기
       - name: Override datasource and Redis for CI services
         run: |
           cat >> .env << 'EOF'
@@ -89,16 +89,7 @@ jobs:
           LOCAL_REDIS_PORT=6379
           EOF
 
-      # Postgres / Redis 가 실제로 응답하는지
-      - name: Infra smoke (PostgreSQL / Redis)
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y postgresql-client redis-tools
-          pg_isready -h 127.0.0.1 -p 5432 -U postgres -d app
-          PGPASSWORD=postgres psql -h 127.0.0.1 -U postgres -d app -c 'SELECT 1'
-          redis-cli -h 127.0.0.1 -p 6379 ping
-
-      # S3: 프로젝트의 AWS SDK v2 + dotenv-java 로 동일 스모크 (Python 단계 제거)
+      # S3: 프로젝트의 AWS SDK v2 + dotenv-java 로 동일 스모크
       - name: Infra smoke (S3)
         run: ./gradlew s3Smoke -x test
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,8 @@ jobs:
           version_label: github-action-${{ steps.current-time.outputs.formattedTime }}
           version_description: ${{ github.ref_name }}@${{ github.sha }}
           deployment_package: deploy/deploy.zip
-          wait_for_deployment: false
+          wait_for_deployment: true
+          wait_for_environment_recovery: 180
       
       - name: Smoke test
         run: |


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #131 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.

CI 실행 중 `sudo apt-get update` 및 `postgresql-client`, `redis-tools` 설치 과정에서 Ubuntu 미러 서버 접속 지연이 발생하여 workflow가 불필요하게 오래 걸리는 문제가 있었습니다.

이에 따라 별도의 apt 기반 PostgreSQL/Redis smoke 단계를 제거하고, 기존 GitHub Actions service container의 health check와 마지막 Spring Boot JAR 기동 후 `/health` 검증 단계로 대체하였습니다.

PostgreSQL과 Redis는 이미 workflow의 `services` 영역에서 health check를 수행하고 있으며, 마지막 단계에서 실제 애플리케이션을 실행할 때 CI용 DB/Redis 환경변수를 주입하고 있습니다. 따라서 앱이 정상적으로 기동되고 `/health`가 200을 반환하면 최소한 애플리케이션이 CI 환경의 DB 설정으로 정상 기동 가능한지 확인할 수 있습니다.

이번 작업을 통해 외부 apt 미러 서버 상태에 따른 CI 지연 가능성을 줄이고, 배포 전 검증 속도를 개선하고자 합니다.

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)

## 🧐 집중 리뷰 요청
