### PR TITLE
[BUG] 연동 시 providerId 보존

### DIFF
--- a/src/main/java/issueissyu/backend/domain/auth/dto/res/LoginLinkResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/auth/dto/res/LoginLinkResDTO.java
@@ -9,9 +9,9 @@ import lombok.Getter;
 @Builder
 public class LoginLinkResDTO {
 
-    private String accessToken;
-    private String refreshToken;
-    private long expiresIn;
+//    private String accessToken;
+//    private String refreshToken;
+//    private long expiresIn;
 
     private String uuid;
 

--- a/src/main/java/issueissyu/backend/domain/auth/dto/res/LoginLinkResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/auth/dto/res/LoginLinkResDTO.java
@@ -9,6 +9,10 @@ import lombok.Getter;
 @Builder
 public class LoginLinkResDTO {
 
+    private String accessToken;
+    private String refreshToken;
+    private long expiresIn;
+
     private String uuid;
 
     @JsonProperty("socialType")

--- a/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
@@ -39,7 +39,8 @@ public enum AuthErrorCode implements BaseErrorCode {
 
     REFRESH_INVALID(HttpStatus.UNAUTHORIZED, "REFRESH_401", "토큰 재발급에 실패했습니다."),
     LOGOUT_INVALID(HttpStatus.UNAUTHORIZED, "LOGOUT_401", "유효하지 않은 토큰입니다."),
-    SIGNOUT_INVALID(HttpStatus.UNAUTHORIZED, "SIGNOUT_401", "유효하지 않은 토큰입니다.");
+    SIGNOUT_INVALID(HttpStatus.UNAUTHORIZED, "SIGNOUT_401", "유효하지 않은 토큰입니다."),
+    SIGNOUT_400(HttpStatus.BAD_REQUEST, "SIGNOUT_400", "회원탈퇴가 불가합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/issueissyu/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/AuthService.java
@@ -15,6 +15,8 @@ import issueissyu.backend.domain.user.util.AppUuid;
 import issueissyu.backend.global.redis.RefreshTokenRedisStore;
 import issueissyu.backend.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +24,7 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -107,11 +110,24 @@ public class AuthService {
     // 회원탈퇴: Redis 토큰 → 사용자 연관 행(PC·알림 등) → OAuth → UserTerm → User 순으로 삭제
     @Transactional
     public void signout(String uid) {
-        refreshTokenRedisStore.deleteAll(uid);
-        userSignOutCleaner.deleteRowsReferencingUser(uid);
-        oAuthRepository.deleteByUserUid(uid);
-        userTermRepository.deleteByUserUid(uid);
-        userRepository.deleteById(uid);
+        try {
+            refreshTokenRedisStore.deleteAll(uid);
+            userSignOutCleaner.deleteRowsReferencingUser(uid);
+            oAuthRepository.deleteByUserUid(uid);
+            userTermRepository.deleteByUserUid(uid);
+            userRepository.deleteById(uid);
+        } catch (Exception e) {
+            Throwable root = NestedExceptionUtils.getMostSpecificCause(e);
+            log.error(
+                    "회원탈퇴 실패 uid={}, topType={}, topMessage={}, rootType={}, rootMessage={}",
+                    uid,
+                    e.getClass().getName(),
+                    e.getMessage(),
+                    root.getClass().getName(),
+                    root.getMessage(),
+                    e);
+            throw AuthException.of(AuthErrorCode.SIGNOUT_400);
+        }
     }
 
     // 네이버 앱 로그인

--- a/src/main/java/issueissyu/backend/domain/auth/service/LoginLinkService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/LoginLinkService.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.Optional;
 
 @Slf4j

--- a/src/main/java/issueissyu/backend/domain/auth/service/LoginLinkService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/LoginLinkService.java
@@ -36,7 +36,7 @@ public class LoginLinkService {
 
     // 처리 순서:
     // 1. 전화번호로 기존 사용자(existingUser) 조회
-    // 2. LOCAL이면 임시 유저의 providerId(로그인 아이디)·password를 삭제 전에 보존
+    // 2. LOCAL이면 임시 유저의 providerId(로그인 아이디)·password를, NAVER 등은 소셜 측 providerId를 삭제 전에 보존
     // 3. tempUid 사용자의 OAuth 레코드 삭제 + User 레코드 삭제
     // 4. existingUser에 새 socialType OAuth 추가 (이미 있으면 스킵)
     // 5. Redis에서 tempUid:socialType 토큰 삭제 후 existingUid:socialType 토큰 신규 발급
@@ -60,7 +60,7 @@ public class LoginLinkService {
             throw AuthException.of(AuthErrorCode.LOGIN_LINK_400_3);
         }
 
-        // 4. LOCAL 연동: 삭제 전에 로그인 아이디(providerId)와 BCrypt 해시 비밀번호를 보존
+        // 4. 연동할 소셜별로 삭제 전에 OAuth providerId(및 LOCAL일 때 password) 보존
         String oauthProviderId = tempUid;
         String oauthPassword   = null;
         if (socialType == SocialType.LOCAL) {
@@ -70,6 +70,18 @@ public class LoginLinkService {
                 oauthProviderId = tempLocalOAuth.get().getProviderId();
                 oauthPassword   = tempLocalOAuth.get().getPassword();
             }
+        } else {
+            Optional<OAuth> tempSocialOAuth =
+                    oAuthRepository.findByUser_UidAndSocialType(tempUid, socialType);
+            if (tempSocialOAuth.isEmpty()) {
+                log.warn(
+                        "로그인 연동 실패: tempUid={} 에 {} OAuth가 없어 providerId를 복사할 수 없음",
+                        tempUid,
+                        socialType);
+                throw AuthException.of(AuthErrorCode.LOGIN_LINK_400);
+            }
+            oauthProviderId = tempSocialOAuth.get().getProviderId();
+            oauthPassword   = tempSocialOAuth.get().getPassword();
         }
 
         // 5. tempUid 사용자 완전 제거 (OAuth → UserTerm → User 순서)

--- a/src/main/java/issueissyu/backend/domain/auth/service/LoginLinkService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/LoginLinkService.java
@@ -105,7 +105,7 @@ public class LoginLinkService {
         String newAccessToken = jwtTokenProvider.createAccessToken(existingUid);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(existingUid, provider);
         refreshTokenRedisStore.save(existingUid, provider, newRefreshToken,
-                java.time.Duration.ofMillis(jwtTokenProvider.getRefreshExpMs()));
+                Duration.ofMillis(jwtTokenProvider.getRefreshExpMs()));
 
         log.info("로그인 연동 완료: tempUid={} → existingUid={}, socialType={}", tempUid, existingUid, socialType);
 

--- a/src/main/java/issueissyu/backend/domain/auth/service/LoginLinkService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/LoginLinkService.java
@@ -109,9 +109,9 @@ public class LoginLinkService {
         log.info("로그인 연동 완료: tempUid={} → existingUid={}, socialType={}", tempUid, existingUid, socialType);
 
         return LoginLinkResDTO.builder()
-                .accessToken(newAccessToken)
-                .refreshToken(newRefreshToken)
-                .expiresIn(jwtTokenProvider.getAccessExpMs() / 1000)
+                //.accessToken(newAccessToken)
+                //.refreshToken(newRefreshToken)
+                //.expiresIn(jwtTokenProvider.getAccessExpMs() / 1000)
                 .uuid(existingUid)
                 .socialType(socialType.name())
                 .nickname(existingUser.getNickname())

--- a/src/main/java/issueissyu/backend/domain/auth/service/LoginLinkService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/LoginLinkService.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.util.Optional;
 
 @Slf4j
@@ -90,13 +89,17 @@ public class LoginLinkService {
         String provider = socialType.name().toLowerCase();
         refreshTokenRedisStore.delete(tempUid, provider);
 
+        String newAccessToken = jwtTokenProvider.createAccessToken(existingUid);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(existingUid, provider);
         refreshTokenRedisStore.save(existingUid, provider, newRefreshToken,
-                Duration.ofMillis(jwtTokenProvider.getRefreshExpMs()));
+                java.time.Duration.ofMillis(jwtTokenProvider.getRefreshExpMs()));
 
         log.info("로그인 연동 완료: tempUid={} → existingUid={}, socialType={}", tempUid, existingUid, socialType);
 
         return LoginLinkResDTO.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .expiresIn(jwtTokenProvider.getAccessExpMs() / 1000)
                 .uuid(existingUid)
                 .socialType(socialType.name())
                 .nickname(existingUser.getNickname())

--- a/src/main/java/issueissyu/backend/domain/user/service/UserSignOutCleaner.java
+++ b/src/main/java/issueissyu/backend/domain/user/service/UserSignOutCleaner.java
@@ -16,6 +16,9 @@ public class UserSignOutCleaner {
                     + PIN_IDS_OWNED_BY_USER
                     + ")";
 
+    private static final String EVENT_PIN_IDS_FOR_OWNED_PINS =
+            "(SELECT event_pin_id FROM event_pin WHERE pin_id IN " + PIN_IDS_OWNED_BY_USER + ")";
+
     private final JdbcTemplate jdbcTemplate;
 
     public void deleteRowsReferencingUser(String uid) {
@@ -59,6 +62,9 @@ public class UserSignOutCleaner {
                         + PIN_IDS_OWNED_BY_USER
                         + " OR uid = ?",
                 uid,
+                uid);
+        jdbcTemplate.update(
+                "DELETE FROM store_image WHERE event_pin_id IN " + EVENT_PIN_IDS_FOR_OWNED_PINS,
                 uid);
         jdbcTemplate.update(
                 "DELETE FROM event_pin WHERE pin_id IN " + PIN_IDS_OWNED_BY_USER, uid);

--- a/src/main/java/issueissyu/backend/domain/user/service/UserSignOutCleaner.java
+++ b/src/main/java/issueissyu/backend/domain/user/service/UserSignOutCleaner.java
@@ -75,6 +75,10 @@ public class UserSignOutCleaner {
                 "DELETE FROM pin_location WHERE pin_id IN " + PIN_IDS_OWNED_BY_USER, uid);
         jdbcTemplate.update(
                 "DELETE FROM pin_image WHERE pin_id IN " + PIN_IDS_OWNED_BY_USER, uid);
+        jdbcTemplate.update(
+                "DELETE FROM pin_like WHERE pin_id IN " + PIN_IDS_OWNED_BY_USER + " OR uid = ?",
+                uid,
+                uid);
         jdbcTemplate.update("DELETE FROM pin WHERE uid = ?", uid);
 
         jdbcTemplate.update(


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #141  
을 야매로 해결해 보는 PR

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.

일단 까먹기 전에 작업해 두었습니다.
우선 머지는 하지 않는 것으로...

로그인 연동 시 날리던 providerId를 보존하도록 작업하였습니다.
기존에는 연동 하는 즉시 providerId를 날려서 연동 후 네이버 재로그인 시 providerId를 DB에서 찾기 못해 새로운 계정이 생성되는 것임을 확인했습니다. 네이버 로그인 연동을 고려하지 못하고 코드를 짜서 발생한 사고 입니다...

jwt 토큰 발급은 uid로 고정입니다.

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.