### PR TITLE
[BUG] 커뮤니티 상세 조회 응답에 청원 수 반환 추가

### DIFF
--- a/src/main/java/issueissyu/backend/domain/community/controller/CommunityController.java
+++ b/src/main/java/issueissyu/backend/domain/community/controller/CommunityController.java
@@ -50,7 +50,12 @@ public class CommunityController {
         return ApiResponse.onSuccess(CommunitySuccessCode.forTab(parsedTab), result);
     }
 
-    @Operation(summary = "커뮤니티 게시물 상세 조회", description = "연결된 핀 카드 정보와 본문(content)을 반환합니다. 조회 시 조회수가 증가합니다.")
+    @Operation(
+            summary = "커뮤니티 게시물 상세 조회",
+            description =
+                    "연결된 핀 카드 정보와 본문(content)을 반환합니다. 조회 시 조회수가 증가합니다. "
+                            + "이슈(ISSUE) 타입일 때만 issuePinState·petitionCount·isPetitioned·isProblemSolver가 채워지며, "
+                            + "그 외 타입에서는 해당 필드가 null입니다.")
     @GetMapping("/{communityId}")
     public ApiResponse<CommunityDetailResDTO> getDetail(
             @PathVariable Long communityId,

--- a/src/main/java/issueissyu/backend/domain/community/dto/res/CommunityDetailResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/community/dto/res/CommunityDetailResDTO.java
@@ -12,6 +12,8 @@ public record CommunityDetailResDTO(
         Boolean isReported,
         Boolean isPetitioned,
         Boolean isProblemSolver,
+        String issuePinState,
+        Integer petitionCount,
         boolean isMine
 ) {
 }

--- a/src/main/java/issueissyu/backend/domain/community/dto/res/IssueCommunityDetailItemResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/community/dto/res/IssueCommunityDetailItemResDTO.java
@@ -12,7 +12,6 @@ public record IssueCommunityDetailItemResDTO(
         String pinUserProfile,
         String pinDetailAddress,
         int viewCount,
-        long likeCount,
-        String issuePinState
+        long likeCount
 ) implements CommunityDetailItemResDTO {
 }

--- a/src/main/java/issueissyu/backend/domain/community/service/query/CommunityQueryServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/community/service/query/CommunityQueryServiceImpl.java
@@ -105,6 +105,10 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
         int viewCount = pinRepository.incrementViewCountAndGetCount(pin.getPinId());
         Long pinId = pin.getPinId();
         CommunityType type = community.getCommunityType();
+        IssuePin issuePin =
+                type == CommunityType.ISSUE
+                        ? issuePinRepository.findByPin_PinId(pinId).orElse(null)
+                        : null;
 
         CommunityDetailItemResDTO item = toDetailItem(community, viewCount);
         List<String> pinImageUrls = pinImageRepository
@@ -131,6 +135,13 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
                 ? problemSolverRepository.existsByIssuePin_Pin_PinIdAndUser_Uid(pinId, uid)
                 : null;
 
+        String issuePinState =
+                issuePin != null ? issuePin.getIssuePinState().name() : null;
+        Integer petitionCount =
+                type == CommunityType.ISSUE
+                        ? (issuePin != null ? issuePin.getPetitionCount() : 0)
+                        : null;
+
         boolean isMine = Objects.equals(pin.getUser().getUid(), uid);
 
         return new CommunityDetailResDTO(
@@ -142,10 +153,12 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
                 isReported,
                 isPetitioned,
                 isProblemSolver,
+                issuePinState,
+                petitionCount,
                 isMine);
     }
 
-    // 상세 조회용 DTO 분기 (ISSUE는 추가 데이터 포함, 나머지는 피드 DTO 재사용)
+    // 상세 조회용 DTO 분기 (타입별 카드 메타; 이슈 전용 상태는 래퍼 필드 참고)
     private CommunityDetailItemResDTO toDetailItem(Community community, int viewCount) {
         return switch (community.getCommunityType()) {
             case ISSUE -> toIssueDetailItem(community, viewCount);
@@ -155,22 +168,21 @@ public class CommunityQueryServiceImpl implements CommunityQueryService {
         };
     }
 
-    // ISSUE 상세 DTO 매핑 (issuePinState 포함)
+    // ISSUE 상세 카드 DTO 매핑 (이슈 진행·청원 수는 래퍼 CommunityDetailResDTO에 포함)
     private IssueCommunityDetailItemResDTO toIssueDetailItem(Community community, int viewCount) {
         Pin pin = community.getPin();
-        IssuePin issuePin = issuePinRepository.findByPin_PinId(pin.getPinId()).orElse(null);
+        Long pinId = pin.getPinId();
 
         return new IssueCommunityDetailItemResDTO(
                 community.getCommunityId(),
-                pin.getPinId(),
+                pinId,
                 community.getTitle(),
-                resolvePinThumbnailUrl(pin.getPinId()).orElse(null),
+                resolvePinThumbnailUrl(pinId).orElse(null),
                 pin.getUser().getNickname(),
                 userProfileImageQueryService.findUrlByUserUid(pin.getUser().getUid()).orElse(null),
-                resolveAddress(pin.getPinId()),
+                resolveAddress(pinId),
                 viewCount,
-                pin.getLikeCount(),
-                issuePin != null ? issuePin.getIssuePinState().name() : null);
+                pin.getLikeCount());
     }
 
     // 탭 규칙에 맞는 community 목록을 조회한다.


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #162 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
커뮤니티 상세 조회 응답에 청원 수를 추가하였습니다 ㅎㅎ...
( 아직 프론트 API 연결 전으로 알고 있습니다. 나중에 커뮤니티 관련 버그, 추가 기능 사항 개발 완료되면 통합해서 머지하면 될 것 같습니다룽 )

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
커뮤니티에서 이슈 핀의 게시물을 조회할 시 아래에 petitionCount를 포함하여 응답합니다.
<img width="2516" height="892" alt="image" src="https://github.com/user-attachments/assets/3d9b6031-aaf2-4fb7-86d0-c0e06f93ca13" />

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
원래는 이슈, PR 을 한꺼번에 하려다가 한 번 나눠서.. 작업해보고 있는데욥.. 혹시 분기 관련해서 조언 주시면 감사하겠습니다...!! 8-8..