### PR TITLE
[FEAT] 소통 핀 수정 통합 API 구현

### DIFF
--- a/src/main/java/issueissyu/backend/domain/pin/controller/PinController.java
+++ b/src/main/java/issueissyu/backend/domain/pin/controller/PinController.java
@@ -3,26 +3,20 @@ package issueissyu.backend.domain.pin.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import issueissyu.backend.domain.pin.dto.req.CommunicationPinEditReqDTO;
-import issueissyu.backend.domain.pin.dto.req.CommunicationPinImportReqDTO;
 import issueissyu.backend.domain.pin.dto.req.DeclarationReqDTO;
 import issueissyu.backend.domain.pin.dto.res.CommunicationPinEditResDTO;
-import issueissyu.backend.domain.pin.dto.res.CommunicationPinImportResDTO;
 import issueissyu.backend.domain.pin.dto.res.PinHomeResDTO;
-import issueissyu.backend.domain.pin.dto.res.PinImageUploadUrlsResDTO;
 import issueissyu.backend.domain.pin.dto.res.PinPostResDTO;
 import issueissyu.backend.domain.pin.dto.res.PinSolveResDTO;
 import issueissyu.backend.domain.pin.exception.code.PinSuccessCode;
 import issueissyu.backend.domain.pin.service.command.DeclarationCommandService;
 import issueissyu.backend.domain.pin.service.command.PinCommunicationCommandService;
 import issueissyu.backend.domain.pin.service.command.PinDeleteCommandService;
-import issueissyu.backend.domain.pin.service.command.PinImageUploadCommandService;
 import issueissyu.backend.domain.pin.service.query.PinDetailQueryService;
 import issueissyu.backend.domain.pin.service.query.PinSolveQueryService;
 import issueissyu.backend.global.api.ApiResponse;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,9 +26,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/pins")
@@ -42,30 +34,11 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "Pin", description = "핀 등록/수정/삭제/조회")
 public class PinController {
 
-    private final PinImageUploadCommandService pinImageUploadCommandService;
     private final PinCommunicationCommandService pinCommunicationCommandService;
     private final DeclarationCommandService declarationCommandService;
     private final PinDeleteCommandService pinDeleteCommandService;
     private final PinDetailQueryService pinDetailQueryService;
     private final PinSolveQueryService pinSolveQueryService;
-
-    @Operation(summary = "핀 이미지 업로드", description = "multipart photos (최대 5장, 합계 50MB)")
-    @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<PinImageUploadUrlsResDTO> uploadPinImages(
-            @AuthenticationPrincipal String uid,
-            @RequestPart("photos") List<MultipartFile> photos) {
-        List<String> urls = pinImageUploadCommandService.uploadPinImages(photos == null ? List.of() : photos);
-        return ApiResponse.onSuccess(
-                PinSuccessCode.PIN_IMAGE_200, new PinImageUploadUrlsResDTO(urls));
-    }
-
-    @Operation(summary = "소통 핀 등록")
-    @PostMapping("/import/communication")
-    public ApiResponse<CommunicationPinImportResDTO> importCommunication(
-            @AuthenticationPrincipal String uid, @Valid @RequestBody CommunicationPinImportReqDTO request) {
-        CommunicationPinImportResDTO res = pinCommunicationCommandService.importCommunication(uid, request);
-        return ApiResponse.onSuccess(PinSuccessCode.PIN_IMPORT_COMMUNICATION_200, res);
-    }
 
     @Operation(summary = "소통 핀 수정")
     @PutMapping("/{pinId}/edit/communication")

--- a/src/main/java/issueissyu/backend/domain/pin/controller/PinController.java
+++ b/src/main/java/issueissyu/backend/domain/pin/controller/PinController.java
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -67,10 +66,10 @@ public class PinController {
         return ApiResponse.onSuccess(PinSuccessCode.PIN_DECLARATION_200, null);
     }
 
-    @Operation(summary = "핀 상세 홈", description = "필수 쿼리 pinId. 조회 시 viewCount(조회수) 중복 집계.")
-    @GetMapping("/home")
+    @Operation(summary = "핀 상세 홈", description = "조회 시 viewCount(조회수) 중복 집계.")
+    @GetMapping("/{pinId}/home")
     public ApiResponse<PinHomeResDTO> getPinHome(
-            @AuthenticationPrincipal String uid, @RequestParam Long pinId) {
+            @AuthenticationPrincipal String uid, @PathVariable Long pinId) {
         PinDetailQueryService.PinHomeResult r = pinDetailQueryService.getPinHome(pinId, uid);
         return ApiResponse.onSuccess(r.successCode(), r.data());
     }

--- a/src/main/java/issueissyu/backend/domain/pin/controller/PinController.java
+++ b/src/main/java/issueissyu/backend/domain/pin/controller/PinController.java
@@ -2,15 +2,12 @@ package issueissyu.backend.domain.pin.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import issueissyu.backend.domain.pin.dto.req.CommunicationPinEditReqDTO;
 import issueissyu.backend.domain.pin.dto.req.DeclarationReqDTO;
-import issueissyu.backend.domain.pin.dto.res.CommunicationPinEditResDTO;
 import issueissyu.backend.domain.pin.dto.res.PinHomeResDTO;
 import issueissyu.backend.domain.pin.dto.res.PinPostResDTO;
 import issueissyu.backend.domain.pin.dto.res.PinSolveResDTO;
 import issueissyu.backend.domain.pin.exception.code.PinSuccessCode;
 import issueissyu.backend.domain.pin.service.command.DeclarationCommandService;
-import issueissyu.backend.domain.pin.service.command.PinCommunicationCommandService;
 import issueissyu.backend.domain.pin.service.command.PinDeleteCommandService;
 import issueissyu.backend.domain.pin.service.query.PinDetailQueryService;
 import issueissyu.backend.domain.pin.service.query.PinSolveQueryService;
@@ -22,7 +19,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,21 +29,10 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Pin", description = "핀 등록/수정/삭제/조회")
 public class PinController {
 
-    private final PinCommunicationCommandService pinCommunicationCommandService;
     private final DeclarationCommandService declarationCommandService;
     private final PinDeleteCommandService pinDeleteCommandService;
     private final PinDetailQueryService pinDetailQueryService;
     private final PinSolveQueryService pinSolveQueryService;
-
-    @Operation(summary = "소통 핀 수정")
-    @PutMapping("/{pinId}/edit/communication")
-    public ApiResponse<CommunicationPinEditResDTO> editCommunication(
-            @AuthenticationPrincipal String uid,
-            @PathVariable Long pinId,
-            @Valid @RequestBody CommunicationPinEditReqDTO request) {
-        CommunicationPinEditResDTO res = pinCommunicationCommandService.editCommunication(uid, pinId, request);
-        return ApiResponse.onSuccess(PinSuccessCode.PIN_EDIT_COMMUNICATION_200, res);
-    }
 
     @Operation(summary = "핀 삭제")
     @DeleteMapping("/{pinId}/delete")

--- a/src/main/java/issueissyu/backend/domain/pin/controller/PinV1Controller.java
+++ b/src/main/java/issueissyu/backend/domain/pin/controller/PinV1Controller.java
@@ -26,9 +26,9 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.util.StringUtils;
 
 @RestController
-@RequestMapping("/api/v1/pins")
+@RequestMapping("/api/pins")
 @RequiredArgsConstructor
-@Tag(name = "Pin V1", description = "통합 멀티파트 핀 등록 API")
+@Tag(name = "Pin", description = "핀 등록/수정/삭제/조회")
 public class PinV1Controller {
 
     private final PinCommunicationCommandService pinCommunicationCommandService;
@@ -36,11 +36,11 @@ public class PinV1Controller {
     private final Validator validator;
 
     @Operation(
-            summary = "소통 핀 통합 등록(V1)",
+            summary = "소통 핀 통합 등록",
             description =
                     "photos(선택, 이미지 파일들)와 request(JSON: 위/경도, 제목, 본문, 이미지별 isMain)를 받아 필요 시 S3 업로드 후 소통 핀을 등록합니다.")
     @PostMapping(value = "/import/communication", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<CommunicationPinImportResDTO> importCommunicationV1(
+    public ApiResponse<CommunicationPinImportResDTO> importCommunication(
             @AuthenticationPrincipal String uid,
             @Parameter(description = "`CommunicationPinImportMultipartReqDTO`와 동일한 필드를 가진 JSON 문자열(lat, lng, pinImages?, pinTitle, pinContent)")
             @RequestPart("request") String requestPart,

--- a/src/main/java/issueissyu/backend/domain/pin/controller/PinV1Controller.java
+++ b/src/main/java/issueissyu/backend/domain/pin/controller/PinV1Controller.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -61,17 +62,31 @@ public class PinV1Controller {
                     photos(선택)와 request(JSON: 제목, 본문, 이미지별 isMain)를 받아 필요 시 S3 업로드 후 소통 핀을 수정합니다.
                     위도·경도·region 은 수정할 수 없습니다. pinImages 와 photos 는 인덱스 1:1 대응합니다.
                     """)
-    @PutMapping(value = "/{pinId}/edit/communication", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<CommunicationPinEditResDTO> editCommunication(
+    @PatchMapping(value = "/{pinId}/edit/communication", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<CommunicationPinEditResDTO> patchCommunication(
             @AuthenticationPrincipal String uid,
             @PathVariable Long pinId,
-            @Parameter(description = "`CommunicationPinEditMultipartReqDTO`와 동일한 필드를 가진 JSON 문자열(pinImages, pinTitle, pinContent)")
-            @RequestPart("request") String requestPart,
+            @Parameter(
+                            description =
+                                    "`CommunicationPinEditMultipartReqDTO` JSON(pinImageUrls?, pinImages?, pinTitle, pinContent)")
+                    @RequestPart("request")
+                    String requestPart,
             @RequestPart(value = "photos", required = false) List<MultipartFile> photos) {
         CommunicationPinEditMultipartReqDTO request = parseEditMultipartRequestBody(requestPart);
         CommunicationPinEditResDTO res =
                 pinCommunicationCommandService.editCommunicationV1(uid, pinId, request, photos);
         return ApiResponse.onSuccess(PinSuccessCode.PIN_EDIT_COMMUNICATION_200, res);
+    }
+
+    // @deprecated PATCH /{pinId}/edit/communication 사용
+    @Deprecated
+    @PutMapping(value = "/{pinId}/edit/communication", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<CommunicationPinEditResDTO> editCommunication(
+            @AuthenticationPrincipal String uid,
+            @PathVariable Long pinId,
+            @RequestPart("request") String requestPart,
+            @RequestPart(value = "photos", required = false) List<MultipartFile> photos) {
+        return patchCommunication(uid, pinId, requestPart, photos);
     }
 
     private CommunicationPinImportMultipartReqDTO parseMultipartRequestBody(String requestPart) {

--- a/src/main/java/issueissyu/backend/domain/pin/controller/PinV1Controller.java
+++ b/src/main/java/issueissyu/backend/domain/pin/controller/PinV1Controller.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import issueissyu.backend.domain.pin.dto.req.CommunicationPinEditMultipartReqDTO;
 import issueissyu.backend.domain.pin.dto.req.CommunicationPinImportMultipartReqDTO;
+import issueissyu.backend.domain.pin.dto.res.CommunicationPinEditResDTO;
 import issueissyu.backend.domain.pin.dto.res.CommunicationPinImportResDTO;
 import issueissyu.backend.domain.pin.exception.PinException;
 import issueissyu.backend.domain.pin.exception.code.PinErrorCode;
@@ -18,7 +20,9 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,6 +54,26 @@ public class PinV1Controller {
         return ApiResponse.onSuccess(PinSuccessCode.PIN_IMPORT_COMMUNICATION_200, res);
     }
 
+    @Operation(
+            summary = "소통 핀 통합 수정",
+            description =
+                    """
+                    photos(선택)와 request(JSON: 제목, 본문, 이미지별 isMain)를 받아 필요 시 S3 업로드 후 소통 핀을 수정합니다.
+                    위도·경도·region 은 수정할 수 없습니다. pinImages 와 photos 는 인덱스 1:1 대응합니다.
+                    """)
+    @PutMapping(value = "/{pinId}/edit/communication", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<CommunicationPinEditResDTO> editCommunication(
+            @AuthenticationPrincipal String uid,
+            @PathVariable Long pinId,
+            @Parameter(description = "`CommunicationPinEditMultipartReqDTO`와 동일한 필드를 가진 JSON 문자열(pinImages, pinTitle, pinContent)")
+            @RequestPart("request") String requestPart,
+            @RequestPart(value = "photos", required = false) List<MultipartFile> photos) {
+        CommunicationPinEditMultipartReqDTO request = parseEditMultipartRequestBody(requestPart);
+        CommunicationPinEditResDTO res =
+                pinCommunicationCommandService.editCommunicationV1(uid, pinId, request, photos);
+        return ApiResponse.onSuccess(PinSuccessCode.PIN_EDIT_COMMUNICATION_200, res);
+    }
+
     private CommunicationPinImportMultipartReqDTO parseMultipartRequestBody(String requestPart) {
         if (!StringUtils.hasText(requestPart)) {
             throw PinException.of(PinErrorCode.PIN_IMPORT_COMMUNICATION_400_1);
@@ -66,6 +90,25 @@ public class PinV1Controller {
             throw e;
         } catch (Exception e) {
             throw PinException.of(PinErrorCode.PIN_IMPORT_COMMUNICATION_400_1);
+        }
+    }
+
+    private CommunicationPinEditMultipartReqDTO parseEditMultipartRequestBody(String requestPart) {
+        if (!StringUtils.hasText(requestPart)) {
+            throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
+        }
+        try {
+            CommunicationPinEditMultipartReqDTO dto =
+                    objectMapper.readValue(requestPart.trim(), CommunicationPinEditMultipartReqDTO.class);
+            Set<ConstraintViolation<CommunicationPinEditMultipartReqDTO>> violations = validator.validate(dto);
+            if (!violations.isEmpty()) {
+                throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
+            }
+            return dto;
+        } catch (PinException e) {
+            throw e;
+        } catch (Exception e) {
+            throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
         }
     }
 }

--- a/src/main/java/issueissyu/backend/domain/pin/controller/TestPinController.java
+++ b/src/main/java/issueissyu/backend/domain/pin/controller/TestPinController.java
@@ -1,0 +1,50 @@
+package issueissyu.backend.domain.pin.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import issueissyu.backend.domain.pin.dto.req.CommunicationPinImportReqDTO;
+import issueissyu.backend.domain.pin.dto.res.CommunicationPinImportResDTO;
+import issueissyu.backend.domain.pin.dto.res.PinImageUploadUrlsResDTO;
+import issueissyu.backend.domain.pin.exception.code.PinSuccessCode;
+import issueissyu.backend.domain.pin.service.command.PinCommunicationCommandService;
+import issueissyu.backend.domain.pin.service.command.PinImageUploadCommandService;
+import issueissyu.backend.global.api.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/test/pins")
+@RequiredArgsConstructor
+@Tag(name = "Pin Test", description = "핀 테스트용 API")
+public class TestPinController {
+
+    private final PinImageUploadCommandService pinImageUploadCommandService;
+    private final PinCommunicationCommandService pinCommunicationCommandService;
+
+    @Operation(summary = "핀 이미지 업로드", description = "multipart photos (최대 5장, 합계 50MB)")
+    @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<PinImageUploadUrlsResDTO> uploadPinImages(
+            @AuthenticationPrincipal String uid,
+            @RequestPart("photos") List<MultipartFile> photos) {
+        List<String> urls = pinImageUploadCommandService.uploadPinImages(photos == null ? List.of() : photos);
+        return ApiResponse.onSuccess(
+                PinSuccessCode.PIN_IMAGE_200, new PinImageUploadUrlsResDTO(urls));
+    }
+
+    @Operation(summary = "소통 핀 등록 (테스트)", description = "JSON Body 기반 소통 핀 등록")
+    @PostMapping("/import/communication")
+    public ApiResponse<CommunicationPinImportResDTO> importCommunication(
+            @AuthenticationPrincipal String uid, @Valid @RequestBody CommunicationPinImportReqDTO request) {
+        CommunicationPinImportResDTO res = pinCommunicationCommandService.importCommunication(uid, request);
+        return ApiResponse.onSuccess(PinSuccessCode.PIN_IMPORT_COMMUNICATION_200, res);
+    }
+}

--- a/src/main/java/issueissyu/backend/domain/pin/dto/req/CommunicationPinEditMultipartReqDTO.java
+++ b/src/main/java/issueissyu/backend/domain/pin/dto/req/CommunicationPinEditMultipartReqDTO.java
@@ -2,11 +2,13 @@ package issueissyu.backend.domain.pin.dto.req;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record CommunicationPinEditMultipartReqDTO(
-        @NotNull @Valid @Size(max = 5) List<CommunicationPinImportMultipartImageReqDTO> pinImages,
+        // 유지할 기존 이미지(URL + isMain). null 이면 photos 도 없을 때 이미지 변경 없음
+        @Valid @Size(max = 5) List<PinImageItemReqDTO> pinImageUrls,
+        // 새로 업로드할 photos 와 1:1 대응하는 isMain. null 이면 빈 목록
+        @Valid @Size(max = 5) List<CommunicationPinImportMultipartImageReqDTO> pinImages,
         @NotBlank String pinTitle,
         @NotBlank String pinContent) {}

--- a/src/main/java/issueissyu/backend/domain/pin/dto/req/CommunicationPinEditMultipartReqDTO.java
+++ b/src/main/java/issueissyu/backend/domain/pin/dto/req/CommunicationPinEditMultipartReqDTO.java
@@ -1,0 +1,12 @@
+package issueissyu.backend.domain.pin.dto.req;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record CommunicationPinEditMultipartReqDTO(
+        @NotNull @Valid @Size(max = 5) List<CommunicationPinImportMultipartImageReqDTO> pinImages,
+        @NotBlank String pinTitle,
+        @NotBlank String pinContent) {}

--- a/src/main/java/issueissyu/backend/domain/pin/dto/req/CommunicationPinEditReqDTO.java
+++ b/src/main/java/issueissyu/backend/domain/pin/dto/req/CommunicationPinEditReqDTO.java
@@ -2,12 +2,12 @@ package issueissyu.backend.domain.pin.dto.req;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 public record CommunicationPinEditReqDTO(
-        @NotNull @Valid @Size(max = 5) List<PinImageItemReqDTO> pinImageUrls,
+        // null 이면 pin_image 를 변경하지 않음
+        @Valid @Size(max = 5) List<PinImageItemReqDTO> pinImageUrls,
         @NotBlank String pinTitle,
         @NotBlank String pinContent) {}

--- a/src/main/java/issueissyu/backend/domain/pin/dto/res/CommunicationPinEditResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/pin/dto/res/CommunicationPinEditResDTO.java
@@ -1,12 +1,17 @@
 package issueissyu.backend.domain.pin.dto.res;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record CommunicationPinEditResDTO(
+        Long pinId,
+        String pinType,
+        String region,
+        String pinDetailAddress,
         List<PinImageWithIdResDTO> pinImageUrls,
+        @JsonProperty("toneType") String toneType,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss.SSSSSS")
         LocalDateTime createdAt,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss.SSSSSS")

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinCommunicationCommandService.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinCommunicationCommandService.java
@@ -1,6 +1,7 @@
 package issueissyu.backend.domain.pin.service.command;
 
 import issueissyu.backend.domain.pin.dto.req.CommunicationPinEditReqDTO;
+import issueissyu.backend.domain.pin.dto.req.CommunicationPinEditMultipartReqDTO;
 import issueissyu.backend.domain.pin.dto.req.CommunicationPinImportReqDTO;
 import issueissyu.backend.domain.pin.dto.req.CommunicationPinImportMultipartReqDTO;
 import issueissyu.backend.domain.pin.dto.res.CommunicationPinEditResDTO;
@@ -16,4 +17,7 @@ public interface PinCommunicationCommandService {
             String uid, CommunicationPinImportMultipartReqDTO request, List<MultipartFile> photos);
 
     CommunicationPinEditResDTO editCommunication(String uid, Long pinId, CommunicationPinEditReqDTO request);
+
+    CommunicationPinEditResDTO editCommunicationV1(
+            String uid, Long pinId, CommunicationPinEditMultipartReqDTO request, List<MultipartFile> photos);
 }

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinCommunicationCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinCommunicationCommandServiceImpl.java
@@ -43,6 +43,7 @@ import org.postgresql.geometric.PGpoint;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -169,22 +170,28 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
     public CommunicationPinEditResDTO editCommunicationV1(
             String uid, Long pinId, CommunicationPinEditMultipartReqDTO req, List<MultipartFile> photos) {
         List<MultipartFile> photoParts = photos == null ? List.of() : photos;
+        List<PinImageItemReqDTO> existingItems = normalizePinImageUrls(req.pinImageUrls());
+        List<CommunicationPinImportMultipartImageReqDTO> newImageMeta =
+                req.pinImages() == null ? List.of() : req.pinImages();
 
-        validateMultipartEditRequest(req, photoParts);
+        validateMultipartEditRequest(existingItems, newImageMeta, photoParts);
 
         if (photoParts.isEmpty()) {
             return editCommunication(
-                    uid, pinId, new CommunicationPinEditReqDTO(List.of(), req.pinTitle(), req.pinContent()));
+                    uid,
+                    pinId,
+                    new CommunicationPinEditReqDTO(existingItems, req.pinTitle(), req.pinContent()));
         }
 
         List<String> uploadedUrls = pinImageUploadCommandService.uploadPinImages(photoParts);
         try {
-            List<PinImageItemReqDTO> pinImageUrls =
-                    buildPinImageItemRequests(uploadedUrls, req.pinImages());
+            List<PinImageItemReqDTO> newItems = buildPinImageItemRequests(uploadedUrls, newImageMeta);
+            List<PinImageItemReqDTO> merged = mergePinImageItems(existingItems, newItems);
+            validateCombinedEditPinImages(merged);
             return editCommunication(
                     uid,
                     pinId,
-                    new CommunicationPinEditReqDTO(pinImageUrls, req.pinTitle(), req.pinContent()));
+                    new CommunicationPinEditReqDTO(merged, req.pinTitle(), req.pinContent()));
         } catch (RuntimeException e) {
             rollbackUploadedUrls(uploadedUrls);
             throw e;
@@ -206,11 +213,13 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
         }
 
         try {
-            validateCommunicationEditPinImages(req.pinImageUrls());
+            if (req.pinImageUrls() != null) {
+                assertPinImageUrlsBelongToPin(pinId, req.pinImageUrls());
+                validateCommunicationEditPinImages(req.pinImageUrls());
+                syncPinImages(pin, req.pinImageUrls());
+            }
 
             pin.updatePinDetails(req.pinTitle(), req.pinContent());
-
-            syncPinImages(pin, req.pinImageUrls());
 
             pinRepository.save(pin);
 
@@ -228,6 +237,38 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
         } catch (Exception e) {
             throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_5);
         }
+    }
+
+    private void assertPinImageUrlsBelongToPin(Long pinId, List<PinImageItemReqDTO> items) {
+        for (PinImageItemReqDTO item : items) {
+            resolveExistingPinImageByUrl(pinId, item.pinImageUrl())
+                    .orElseThrow(() -> PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1));
+        }
+    }
+
+    private static List<PinImageItemReqDTO> normalizePinImageUrls(List<PinImageItemReqDTO> pinImageUrls) {
+        return pinImageUrls == null ? null : List.copyOf(pinImageUrls);
+    }
+
+    private static List<PinImageItemReqDTO> mergePinImageItems(
+            List<PinImageItemReqDTO> existingItems, List<PinImageItemReqDTO> newItems) {
+        if (existingItems == null || existingItems.isEmpty()) {
+            return List.copyOf(newItems);
+        }
+        if (newItems.isEmpty()) {
+            return List.copyOf(existingItems);
+        }
+        List<PinImageItemReqDTO> merged = new ArrayList<>(existingItems.size() + newItems.size());
+        merged.addAll(existingItems);
+        merged.addAll(newItems);
+        return merged;
+    }
+
+    private static void validateCombinedEditPinImages(List<PinImageItemReqDTO> merged) {
+        if (merged.size() > 5) {
+            throw PinException.of(PinErrorCode.PIN_IMAGE_400_3);
+        }
+        validateMainFlags(merged, PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
     }
 
     private void syncPinImages(Pin pin, List<PinImageItemReqDTO> items) {
@@ -334,7 +375,7 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
 
     private static void validateCommunicationEditPinImages(List<PinImageItemReqDTO> items) {
         if (items == null) {
-            throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
+            return;
         }
         validateMainFlags(items, PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
     }
@@ -350,22 +391,21 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
     }
 
     private static void validateMultipartEditRequest(
-            CommunicationPinEditMultipartReqDTO req, List<MultipartFile> photos) {
-        if (req == null) {
-            throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
-        }
-        List<CommunicationPinImportMultipartImageReqDTO> pinMeta = req.pinImages();
-        if (pinMeta == null) {
-            throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
-        }
+            List<PinImageItemReqDTO> existingItems,
+            List<CommunicationPinImportMultipartImageReqDTO> newImageMeta,
+            List<MultipartFile> photos) {
         if (photos.isEmpty()) {
-            if (!pinMeta.isEmpty()) {
+            if (!newImageMeta.isEmpty()) {
                 throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
             }
             return;
         }
-        if (pinMeta.size() != photos.size()) {
+        if (newImageMeta.size() != photos.size()) {
             throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
+        }
+        int existingCount = existingItems == null ? 0 : existingItems.size();
+        if (existingCount + photos.size() > 5) {
+            throw PinException.of(PinErrorCode.PIN_IMAGE_400_3);
         }
     }
 

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinCommunicationCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinCommunicationCommandServiceImpl.java
@@ -8,6 +8,7 @@ import issueissyu.backend.domain.location.repository.LocationRepository;
 import issueissyu.backend.domain.location.repository.PinLocationRepository;
 import issueissyu.backend.domain.location.service.LocationService;
 import issueissyu.backend.domain.pin.dto.req.CommunicationPinEditReqDTO;
+import issueissyu.backend.domain.pin.dto.req.CommunicationPinEditMultipartReqDTO;
 import issueissyu.backend.domain.pin.dto.req.CommunicationPinImportMultipartImageReqDTO;
 import issueissyu.backend.domain.pin.dto.req.CommunicationPinImportMultipartReqDTO;
 import issueissyu.backend.domain.pin.dto.req.CommunicationPinImportReqDTO;
@@ -165,6 +166,32 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
     }
 
     @Override
+    public CommunicationPinEditResDTO editCommunicationV1(
+            String uid, Long pinId, CommunicationPinEditMultipartReqDTO req, List<MultipartFile> photos) {
+        List<MultipartFile> photoParts = photos == null ? List.of() : photos;
+
+        validateMultipartEditRequest(req, photoParts);
+
+        if (photoParts.isEmpty()) {
+            return editCommunication(
+                    uid, pinId, new CommunicationPinEditReqDTO(List.of(), req.pinTitle(), req.pinContent()));
+        }
+
+        List<String> uploadedUrls = pinImageUploadCommandService.uploadPinImages(photoParts);
+        try {
+            List<PinImageItemReqDTO> pinImageUrls =
+                    buildPinImageItemRequests(uploadedUrls, req.pinImages());
+            return editCommunication(
+                    uid,
+                    pinId,
+                    new CommunicationPinEditReqDTO(pinImageUrls, req.pinTitle(), req.pinContent()));
+        } catch (RuntimeException e) {
+            rollbackUploadedUrls(uploadedUrls);
+            throw e;
+        }
+    }
+
+    @Override
     public CommunicationPinEditResDTO editCommunication(String uid, Long pinId, CommunicationPinEditReqDTO req) {
         Pin pin =
                 pinRepository
@@ -187,19 +214,15 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
 
             pinRepository.save(pin);
 
-            List<PinImageWithIdResDTO> imgs =
-                    pin.getPinImages().stream()
-                            .sorted(java.util.Comparator.comparing(PinImage::getPinImageId))
-                            .map(
-                                    pi ->
-                                            new PinImageWithIdResDTO(
-                                                    pi.getPinImageId(),
-                                                    pi.getPinS3Url(),
-                                                    pi.isMainImage()))
-                            .toList();
+            PinLocation pinLocation =
+                    pinLocationRepository
+                            .findByPin_PinId(pinId)
+                            .orElseThrow(() -> PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_5));
 
-            return new CommunicationPinEditResDTO(
-                    imgs, pin.getCreatedAt(), pin.getUpdatedAt());
+            return toEditRes(
+                    pin,
+                    pinLocation.getLocation().getRegion(),
+                    pinLocation.getDetailAddress());
         } catch (PinException e) {
             throw e;
         } catch (Exception e) {
@@ -286,6 +309,29 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
                 pin.getUpdatedAt());
     }
 
+    private CommunicationPinEditResDTO toEditRes(Pin pin, String region, String pinDetailAddress) {
+        List<PinImageWithIdResDTO> imgs =
+                pin.getPinImages().stream()
+                        .sorted(java.util.Comparator.comparing(PinImage::getPinImageId))
+                        .map(
+                                pi ->
+                                        new PinImageWithIdResDTO(
+                                                pi.getPinImageId(),
+                                                pi.getPinS3Url(),
+                                                pi.isMainImage()))
+                        .toList();
+
+        return new CommunicationPinEditResDTO(
+                pin.getPinId(),
+                pin.getPinType().name(),
+                region,
+                pinDetailAddress,
+                imgs,
+                pin.getToneType().name(),
+                pin.getCreatedAt(),
+                pin.getUpdatedAt());
+    }
+
     private static void validateCommunicationEditPinImages(List<PinImageItemReqDTO> items) {
         if (items == null) {
             throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
@@ -300,6 +346,26 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
         long mains = items.stream().filter(PinImageItemReqDTO::isMain).count();
         if (mains != 1) {
             throw PinException.of(violation);
+        }
+    }
+
+    private static void validateMultipartEditRequest(
+            CommunicationPinEditMultipartReqDTO req, List<MultipartFile> photos) {
+        if (req == null) {
+            throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
+        }
+        List<CommunicationPinImportMultipartImageReqDTO> pinMeta = req.pinImages();
+        if (pinMeta == null) {
+            throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
+        }
+        if (photos.isEmpty()) {
+            if (!pinMeta.isEmpty()) {
+                throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
+            }
+            return;
+        }
+        if (pinMeta.size() != photos.size()) {
+            throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
         }
     }
 

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinCommunicationCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinCommunicationCommandServiceImpl.java
@@ -241,8 +241,13 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
 
     private void assertPinImageUrlsBelongToPin(Long pinId, List<PinImageItemReqDTO> items) {
         for (PinImageItemReqDTO item : items) {
-            resolveExistingPinImageByUrl(pinId, item.pinImageUrl())
-                    .orElseThrow(() -> PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1));
+            pinImageRepository.findAllWithPinByPinS3UrlOrderByPinImageIdAsc(item.pinImageUrl()).stream()
+                    .findFirst()
+                    .ifPresent(pi -> {
+                        if (!Objects.equals(pi.getPin().getPinId(), pinId)) {
+                            throw PinException.of(PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
+                        }
+                    });
         }
     }
 


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #175

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.

기존 API 엔드포인트를 정리하고,
소통 핀 수정 통합 API를 구현합니다.

- POST /api/pins/images → POST test/pins/images
- POST /api/pins/import/communication → POST test/pins/import/communication
- POST /api/v1/pins/import/communication → POST /api/pins/import/communication

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

배포 후 S3 동작 확인이 필요합니다.