### PR TITLE
[FEAT] 게시글 공감하기 기능 추가

### DIFF
--- a/src/main/java/issueissyu/backend/domain/community/controller/CommunityLikeController.java
+++ b/src/main/java/issueissyu/backend/domain/community/controller/CommunityLikeController.java
@@ -40,7 +40,7 @@ public class CommunityLikeController {
     // 헬퍼 메서드
     private Long resolvePinId(Long communityId) {
         return communityRepository
-                .findDetailById(communityId)
+                .findById(communityId)
                 .orElseThrow(() -> CommunityException.of(CommunityErrorCode.COMMUNITY_404_1))
                 .getPin()
                 .getPinId();

--- a/src/main/java/issueissyu/backend/domain/community/controller/CommunityLikeController.java
+++ b/src/main/java/issueissyu/backend/domain/community/controller/CommunityLikeController.java
@@ -1,0 +1,48 @@
+package issueissyu.backend.domain.community.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import issueissyu.backend.domain.community.exception.CommunityException;
+import issueissyu.backend.domain.community.exception.code.CommunityErrorCode;
+import issueissyu.backend.domain.community.exception.code.CommunitySuccessCode;
+import issueissyu.backend.domain.community.repository.CommunityRepository;
+import issueissyu.backend.domain.pin.dto.res.PinLikeResDTO;
+import issueissyu.backend.domain.pin.service.command.PinLikeCommandService;
+import issueissyu.backend.global.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Community Like", description = "커뮤니티 공감 API (핀 공감 로직 공유)")
+@RestController
+@RequestMapping("/api/communities")
+@RequiredArgsConstructor
+public class CommunityLikeController {
+
+    private final CommunityRepository communityRepository;
+    private final PinLikeCommandService pinLikeCommandService;
+
+    @Operation(
+            summary = "커뮤니티 게시물 공감",
+            description =
+                    "communityId로 연결된 pin에 공감합니다. 핀 공감과 동일한 데이터(pin_like, like_count)를 사용하며, 취소는 제공하지 않습니다.")
+    @PostMapping("/{communityId}/like")
+    public ApiResponse<PinLikeResDTO> likeCommunity(
+            @PathVariable Long communityId, @AuthenticationPrincipal String uid) {
+        Long pinId = resolvePinId(communityId);
+        return ApiResponse.onSuccess(
+                CommunitySuccessCode.COMMUNITY_LIKE_200, pinLikeCommandService.likePin(pinId, uid));
+    }
+
+    // 헬퍼 메서드
+    private Long resolvePinId(Long communityId) {
+        return communityRepository
+                .findDetailById(communityId)
+                .orElseThrow(() -> CommunityException.of(CommunityErrorCode.COMMUNITY_404_1))
+                .getPin()
+                .getPinId();
+    }
+}

--- a/src/main/java/issueissyu/backend/domain/community/exception/code/CommunitySuccessCode.java
+++ b/src/main/java/issueissyu/backend/domain/community/exception/code/CommunitySuccessCode.java
@@ -33,6 +33,7 @@ public enum CommunitySuccessCode implements BaseSuccessCode {
     COMMUNITY_CREATE_COMMENT_200(HttpStatus.OK, "COMMUNITY_CREATE_COMMENT_200", "커뮤니티 댓글 작성에 성공했습니다."),
     COMMUNITY_UPDATE_COMMENT_200(HttpStatus.OK, "COMMUNITY_UPDATE_COMMENT_200", "커뮤니티 댓글 수정에 성공했습니다."),
     COMMUNITY_DELETE_COMMENT_200(HttpStatus.OK, "COMMUNITY_DELETE_COMMENT_200", "커뮤니티 댓글 삭제에 성공했습니다."),
+    COMMUNITY_LIKE_200(HttpStatus.OK, "COMMUNITY_LIKE_200", "커뮤니티 게시물 공감에 성공했습니다."),
     COMMUNITY_DECLARATION_200(HttpStatus.OK, "COMMUNITY_DECLARATION_200", "신고가 접수되었습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/issueissyu/backend/domain/community/service/command/CommunicationPinCleaner.java
+++ b/src/main/java/issueissyu/backend/domain/community/service/command/CommunicationPinCleaner.java
@@ -3,6 +3,7 @@ package issueissyu.backend.domain.community.service.command;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -10,6 +11,7 @@ public class CommunicationPinCleaner {
 
     private final JdbcTemplate jdbcTemplate;
 
+    @Transactional
     public void deleteByPinId(Long pinId) {
         jdbcTemplate.update("DELETE FROM pin_emoji     WHERE pin_id = ?", pinId);
         jdbcTemplate.update("DELETE FROM declaration   WHERE pin_id = ?", pinId);

--- a/src/main/java/issueissyu/backend/domain/community/service/command/CommunityPromotionService.java
+++ b/src/main/java/issueissyu/backend/domain/community/service/command/CommunityPromotionService.java
@@ -1,4 +1,4 @@
-package issueissyu.backend.domain.community.service.query;
+package issueissyu.backend.domain.community.service.command;
 
 import issueissyu.backend.domain.community.entity.Community;
 import issueissyu.backend.domain.community.enums.CommunityType;

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinLikeCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinLikeCommandServiceImpl.java
@@ -3,7 +3,7 @@ package issueissyu.backend.domain.pin.service.command;
 import issueissyu.backend.domain.alarm.event.LikeAlarmCreatedEvent;
 import issueissyu.backend.domain.alarm.service.command.LikeAlarmCommandService;
 import issueissyu.backend.domain.alarm.service.command.LikeAlarmPrepared;
-import issueissyu.backend.domain.community.service.query.CommunityPromotionService;
+import issueissyu.backend.domain.community.service.command.CommunityPromotionService;
 import issueissyu.backend.domain.pin.dto.res.PinLikeResDTO;
 import issueissyu.backend.domain.pin.entity.Pin;
 import issueissyu.backend.domain.pin.entity.mapping.PinLike;


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #182 

## ✨ 작업 개요
>커뮤니티에도 공감히기 기능이 추가될 예정이라고 해서 추가하였습니다.

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
1. 커뮤니티 게시물에서 공감하기 기능을 추가하였습니다. ( 핀과 로직을 공유합니다. )
<img width="2126" height="1312" alt="image" src="https://github.com/user-attachments/assets/7ec7f79d-c188-45cc-8fca-1206f3883408" />
2. 실행 후 pin_like 테이블에서 생성되는 모습
<img width="1988" height="532" alt="image" src="https://github.com/user-attachments/assets/16c666da-4929-4415-ab4c-e2a6b00c90c6" />


## 🧐 집중 리뷰 요청