### PR TITLE
[BUG] 이모지 로직 수정

### DIFF
--- a/src/main/java/issueissyu/backend/domain/pin/controller/PinEmojiController.java
+++ b/src/main/java/issueissyu/backend/domain/pin/controller/PinEmojiController.java
@@ -3,6 +3,7 @@ package issueissyu.backend.domain.pin.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import issueissyu.backend.domain.pin.dto.req.ApplyPinEmojiReqDTO;
+import issueissyu.backend.domain.pin.dto.req.RegisterPinEmojiReqDTO;
 import issueissyu.backend.domain.pin.dto.res.ApplyPinEmojiResDTO;
 import issueissyu.backend.domain.pin.dto.res.PinEmojiSummaryListResDTO;
 import issueissyu.backend.domain.pin.exception.code.PinSuccessCode;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,8 +45,26 @@ public class PinEmojiController {
     }
 
     @Operation(
-            summary = "내 핀 반응 토글(등록/해제)",
-            description = "같은 이모지를 다시 요청하면 반응이 해제되고, 다른 이모지를 요청하면 기존 반응은 해제된 뒤 새 반응으로 교체됩니다."
+            summary = "내 핀 반응 등록(피커 확정)",
+            description = "피커에서 선택 후 버튼으로 확정할 때 사용합니다. emojiId=null이면 반응 취소, "
+                    + "값이 있으면 등록/변경합니다(같은 이모지 재전송 시 유지, 토글 해제 없음)."
+    )
+    @PostMapping("/me")
+    public ApiResponse<ApplyPinEmojiResDTO> registerMyEmoji(
+            @PathVariable Long pinId,
+            @AuthenticationPrincipal String uid,
+            @RequestBody RegisterPinEmojiReqDTO request
+    ) {
+        return ApiResponse.onSuccess(
+                PinSuccessCode.APPLY_EMOJI_200,
+                pinEmojiCommandService.registerMyEmoji(pinId, uid, request)
+        );
+    }
+
+    @Operation(
+            summary = "내 핀 반응 토글",
+            description = "이미 남긴 반응을 즉시 조작할 때 사용합니다. 같은 이모지를 다시 요청하면 해제되고, "
+                    + "다른 이모지를 요청하면 교체됩니다."
     )
     @PutMapping("/me")
     public ApiResponse<ApplyPinEmojiResDTO> applyMyEmoji(

--- a/src/main/java/issueissyu/backend/domain/pin/dto/req/RegisterPinEmojiReqDTO.java
+++ b/src/main/java/issueissyu/backend/domain/pin/dto/req/RegisterPinEmojiReqDTO.java
@@ -1,0 +1,13 @@
+package issueissyu.backend.domain.pin.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RegisterPinEmojiReqDTO {
+
+    @Schema(description = "등록할 이모지 ID. null이면 반응 취소(피커에서 선택 해제 후 버튼)", example = "1", nullable = true)
+    private Long emojiId;
+}

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinEmojiCommandService.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinEmojiCommandService.java
@@ -1,8 +1,11 @@
 package issueissyu.backend.domain.pin.service.command;
 
 import issueissyu.backend.domain.pin.dto.req.ApplyPinEmojiReqDTO;
+import issueissyu.backend.domain.pin.dto.req.RegisterPinEmojiReqDTO;
 import issueissyu.backend.domain.pin.dto.res.ApplyPinEmojiResDTO;
 
 public interface PinEmojiCommandService {
+    ApplyPinEmojiResDTO registerMyEmoji(Long pinId, String uid, RegisterPinEmojiReqDTO request);
+
     ApplyPinEmojiResDTO applyMyEmoji(Long pinId, String uid, ApplyPinEmojiReqDTO request);
 }

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinEmojiCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinEmojiCommandServiceImpl.java
@@ -2,6 +2,7 @@ package issueissyu.backend.domain.pin.service.command;
 
 import issueissyu.backend.domain.billing.repository.UserEmojiRepository;
 import issueissyu.backend.domain.pin.dto.req.ApplyPinEmojiReqDTO;
+import issueissyu.backend.domain.pin.dto.req.RegisterPinEmojiReqDTO;
 import issueissyu.backend.domain.pin.dto.res.ApplyPinEmojiResDTO;
 import issueissyu.backend.domain.pin.entity.Emoji;
 import issueissyu.backend.domain.pin.entity.Pin;
@@ -11,7 +12,6 @@ import issueissyu.backend.domain.pin.exception.code.PinErrorCode;
 import issueissyu.backend.domain.pin.repository.EmojiRepository;
 import issueissyu.backend.domain.pin.repository.PinEmojiRepository;
 import issueissyu.backend.domain.pin.repository.PinRepository;
-import issueissyu.backend.domain.pin.service.command.CommunicationPinActivityMarker;
 import issueissyu.backend.domain.user.entity.User;
 import issueissyu.backend.domain.user.repository.UserRepository;
 import issueissyu.backend.global.api.code.GeneralErrorCode;
@@ -33,6 +33,76 @@ public class PinEmojiCommandServiceImpl implements PinEmojiCommandService {
     private final UserEmojiRepository userEmojiRepository;
     private final UserRepository userRepository;
     private final CommunicationPinActivityMarker communicationPinActivityMarker;
+
+    @Override
+    public ApplyPinEmojiResDTO registerMyEmoji(Long pinId, String uid, RegisterPinEmojiReqDTO request) {
+        if (!pinRepository.existsById(pinId)) {
+            throw PinException.of(PinErrorCode.PIN_NOT_FOUND);
+        }
+        userRepository.findById(uid)
+                .orElseThrow(() -> GeneralException.of(GeneralErrorCode.USER_NOT_FOUND));
+
+        // null -> 현재 활성화된 이모지 해제
+        if (request.getEmojiId() == null) {
+            Optional<PinEmoji> currentActiveOpt = pinEmojiRepository.findActiveByPinIdAndUidForUpdate(pinId, uid);
+            if (currentActiveOpt.isEmpty()) {
+                return ApplyPinEmojiResDTO.builder()
+                        .selectedEmojiId(null)
+                        .build();
+            }
+
+            PinEmoji currentActive = currentActiveOpt.get();
+            currentActive.deactivate();
+            pinEmojiRepository.save(currentActive);
+            markPinEmojiReaction(pinId);
+            return ApplyPinEmojiResDTO.builder()
+                    .selectedEmojiId(null)
+                    .build();
+        }
+
+        Pin pin = pinRepository.findById(pinId)
+                .orElseThrow(() -> PinException.of(PinErrorCode.PIN_NOT_FOUND));
+        Emoji targetEmoji = emojiRepository.findById(request.getEmojiId())
+                .orElseThrow(() -> PinException.of(PinErrorCode.EMOJI_NOT_FOUND));
+
+        if (!targetEmoji.isDefault() && !userEmojiRepository.existsByUserUidAndEmojiEmojiId(uid, targetEmoji.getEmojiId())) {
+            throw PinException.of(PinErrorCode.EMOJI_NOT_OWNED);
+        }
+
+        User user = userRepository.findById(uid)
+                .orElseThrow(() -> GeneralException.of(GeneralErrorCode.USER_NOT_FOUND));
+
+        Optional<PinEmoji> currentActiveOpt = pinEmojiRepository.findActiveByPinIdAndUidForUpdate(pinId, uid);
+        Long targetEmojiId = targetEmoji.getEmojiId();
+
+        if (currentActiveOpt.isPresent()) {
+            PinEmoji currentActive = currentActiveOpt.get();
+            if (currentActive.getEmoji().getEmojiId().equals(targetEmojiId)) {
+                return ApplyPinEmojiResDTO.builder()
+                        .selectedEmojiId(targetEmojiId)
+                        .build();
+            }
+
+            currentActive.deactivate();
+            pinEmojiRepository.save(currentActive);
+        }
+
+        PinEmoji targetRow = pinEmojiRepository.findByPinPinIdAndUserUidAndEmojiEmojiId(pinId, uid, targetEmojiId)
+                .orElse(PinEmoji.builder()
+                        .pin(pin)
+                        .user(user)
+                        .emoji(targetEmoji)
+                        .active(false)
+                        .build());
+
+        targetRow.activate();
+        pinEmojiRepository.save(targetRow);
+        markPinEmojiReaction(pinId);
+
+        return ApplyPinEmojiResDTO.builder()
+                .selectedEmojiId(targetEmojiId)
+                .build();
+    }
 
     @Override
     public ApplyPinEmojiResDTO applyMyEmoji(Long pinId, String uid, ApplyPinEmojiReqDTO request) {

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinEmojiCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinEmojiCommandServiceImpl.java
@@ -62,7 +62,7 @@ public class PinEmojiCommandServiceImpl implements PinEmojiCommandService {
             if (currentEmojiId.equals(targetEmojiId)) {
                 currentActive.deactivate();
                 pinEmojiRepository.save(currentActive);
-                communicationPinActivityMarker.markReactionOrComment(pinId);
+                markPinEmojiReaction(pinId);
                 return ApplyPinEmojiResDTO.builder()
                         .selectedEmojiId(null)
                         .build();
@@ -84,10 +84,15 @@ public class PinEmojiCommandServiceImpl implements PinEmojiCommandService {
         targetRow.activate();
         pinEmojiRepository.save(targetRow);
 
-        communicationPinActivityMarker.markReactionOrComment(pinId);
+        markPinEmojiReaction(pinId);
 
         return ApplyPinEmojiResDTO.builder()
                 .selectedEmojiId(targetEmojiId)
                 .build();
+    }
+
+    private void markPinEmojiReaction(Long pinId) {
+        pinEmojiRepository.flush();
+        communicationPinActivityMarker.markReactionOrComment(pinId);
     }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #208 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
1. 기존 토글 방식 API 가 재등록 시 DB에 반영이 잘 안되는 문제가 있었음 -> flush()추가 
2. 프론트와의 논의 후 추가 해야 할 API 가 있음을 깨달음 ㅠㅠ... -> 버튼 방식? 을 추가함
선택한 id 가 null 이면 active 가 true 인 애 끄고
이미 있는거고, true 면 그대로 
이미 있는거고 false 면 키면서 true인 애 끄고...


## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
로컬 DB 로 각 두 api 의 경우에 따라 테스트를 하며 적용이 잘되는지와, 컬럼 추가 없이 활성화 상태만 바뀌는 지를 테스트하였습니다. 

<img width="2780" height="818" alt="image" src="https://github.com/user-attachments/assets/0a86e5b0-a8ba-4d2b-8372-f18ad2bb2f9f" />

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.