### PR TITLE
[FEAT] 컬렉션 조회 시 미션 검증 로직 추가

### DIFF
--- a/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/issueissyu/backend/domain/auth/exception/code/AuthErrorCode.java
@@ -38,6 +38,10 @@ public enum AuthErrorCode implements BaseErrorCode {
     LOGIN_LINK_400_2(HttpStatus.BAD_REQUEST, "LOGIN_LINK_400_2", "연동 대상이 현재 계정과 동일합니다."),
     LOGIN_LINK_400_3(HttpStatus.BAD_REQUEST, "LOGIN_LINK_400_3", "해당 소셜 타입은 이미 연동되어 있습니다."),
     ONBOARDING_400(HttpStatus.BAD_REQUEST, "ONBOARDING_400", "온보딩 실패"),
+    ONBOARDING_500(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "ONBOARDING_500",
+            "필수 컬렉션 데이터가 설정되지 않았습니다."),
 
     REFRESH_INVALID(HttpStatus.UNAUTHORIZED, "REFRESH_401", "토큰 재발급에 실패했습니다."),
     LOGOUT_INVALID(HttpStatus.UNAUTHORIZED, "LOGOUT_401", "유효하지 않은 토큰입니다."),

--- a/src/main/java/issueissyu/backend/domain/auth/service/OnboardingService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/OnboardingService.java
@@ -12,6 +12,7 @@ import issueissyu.backend.domain.user.entity.OAuth;
 import issueissyu.backend.domain.user.entity.User;
 import issueissyu.backend.domain.user.repository.OAuthRepository;
 import issueissyu.backend.domain.user.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OnboardingService {
 
     private static final String DEFAULT_PROFILE_NAME = "default";
+    private static final List<String> STARTER_COLLECTION_NAMES = List.of("무관심", "행복양");
 
     private final UserRepository userRepository;
     private final OAuthRepository oAuthRepository;
@@ -71,6 +73,21 @@ public class OnboardingService {
                                                                 defaultProfile)
                                                         .isProfile(true)
                                                         .build()));
+
+        for (String collectionName : STARTER_COLLECTION_NAMES) {
+            CustomCollection starterCollection = customCollectionRepository
+                    .findByCustomCollectionName(collectionName)
+                    .orElseThrow(() -> AuthException.of(AuthErrorCode.ONBOARDING_400));
+            userCustomCollectionRepository
+                    .findByUser_UidAndCustomCollection_CustomCollectionName(uid, collectionName)
+                    .orElseGet(
+                            () ->
+                                    userCustomCollectionRepository.save(
+                                            UserCustomCollection.builder()
+                                                    .user(user)
+                                                    .customCollection(starterCollection)
+                                                    .build()));
+        }
 
         return OnboardingResDTO.builder()
                 .uuid(user.getUid())

--- a/src/main/java/issueissyu/backend/domain/auth/service/OnboardingService.java
+++ b/src/main/java/issueissyu/backend/domain/auth/service/OnboardingService.java
@@ -49,7 +49,7 @@ public class OnboardingService {
 
         CustomCollection defaultProfile = customCollectionRepository
                 .findByCustomCollectionName(DEFAULT_PROFILE_NAME)
-                .orElseThrow(() -> AuthException.of(AuthErrorCode.ONBOARDING_400));
+                .orElseThrow(() -> AuthException.of(AuthErrorCode.ONBOARDING_500));
 
         UserCustomCollection savedProfile =
                 userCustomCollectionRepository
@@ -77,7 +77,7 @@ public class OnboardingService {
         for (String collectionName : STARTER_COLLECTION_NAMES) {
             CustomCollection starterCollection = customCollectionRepository
                     .findByCustomCollectionName(collectionName)
-                    .orElseThrow(() -> AuthException.of(AuthErrorCode.ONBOARDING_400));
+                    .orElseThrow(() -> AuthException.of(AuthErrorCode.ONBOARDING_500));
             userCustomCollectionRepository
                     .findByUser_UidAndCustomCollection_CustomCollectionName(uid, collectionName)
                     .orElseGet(

--- a/src/main/java/issueissyu/backend/domain/collection/controller/CustomCollectionController.java
+++ b/src/main/java/issueissyu/backend/domain/collection/controller/CustomCollectionController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -39,10 +40,13 @@ public class CustomCollectionController {
                     collections 는 잠금·북마크 상태(isLocked, isBookmarked)를 포함한 전체 목록이며, 서버에서 북마크 항목만 걸러내지 않습니다.
                     마이페이지 컬렉션 영역은 클라이언트에서 collections 중 isLocked == false && isBookmarked == true 항목만 표시하면 됩니다.
                     myCollection 은 대표 프로필 컬렉션 요약입니다.
+                    checkUnlock=true 이면 미션 조건을 검사해 해금하고, 이번 요청에서 새로 풀린 항목을 newlyUnlocked 에 담습니다. (컬렉션 화면 진입 시 사용)
                     """)
     @GetMapping
-    public ApiResponse<MyCollectionsResDTO> getMyCollections(@AuthenticationPrincipal String uid) {
-        MyCollectionsResDTO result = userCustomCollectionQueryService.getMyCollections(uid);
+    public ApiResponse<MyCollectionsResDTO> getMyCollections(
+            @AuthenticationPrincipal String uid,
+            @RequestParam(defaultValue = "false") boolean checkUnlock) {
+        MyCollectionsResDTO result = userCustomCollectionQueryService.getMyCollections(uid, checkUnlock);
         return ApiResponse.onSuccess(CustomCollectionSuccessCode.USER_COLLECTIONS_GET_SUCCESS, result);
     }
 

--- a/src/main/java/issueissyu/backend/domain/collection/dto/res/MyCollectionsResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/collection/dto/res/MyCollectionsResDTO.java
@@ -18,4 +18,7 @@ public class MyCollectionsResDTO {
 
     // 전체 컬렉션 카탈로그(ID 순). isLocked·isBookmarked 포함. 마이페이지 노출 필터는 클라이언트에서 적용.
     private List<UserCollectionItemResDTO> collections;
+
+    // checkUnlock=true 요청에서 이번에 새로 해금된 컬렉션 (연출용)
+    private List<NewlyUnlockedCollectionResDTO> newlyUnlocked;
 }

--- a/src/main/java/issueissyu/backend/domain/collection/dto/res/NewlyUnlockedCollectionResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/collection/dto/res/NewlyUnlockedCollectionResDTO.java
@@ -1,0 +1,19 @@
+package issueissyu.backend.domain.collection.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NewlyUnlockedCollectionResDTO {
+
+    private Long collectionId;
+    private String name;
+    private String imageUrl;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private String unlockCondition;
+}

--- a/src/main/java/issueissyu/backend/domain/collection/service/command/CollectionUnlockService.java
+++ b/src/main/java/issueissyu/backend/domain/collection/service/command/CollectionUnlockService.java
@@ -1,0 +1,9 @@
+package issueissyu.backend.domain.collection.service.command;
+
+import issueissyu.backend.domain.collection.dto.res.NewlyUnlockedCollectionResDTO;
+import java.util.List;
+
+public interface CollectionUnlockService {
+
+    List<NewlyUnlockedCollectionResDTO> evaluateAndUnlockMissions(String uid);
+}

--- a/src/main/java/issueissyu/backend/domain/collection/service/command/CollectionUnlockServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/collection/service/command/CollectionUnlockServiceImpl.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CollectionUnlockServiceImpl implements CollectionUnlockService {
 
-    private static final String LIKE_MISSION_COLLECTION_NAME = "음흉씨";
+    private static final String LIKE_MISSION_COLLECTION_NAME = "버터떡";
     private static final int REQUIRED_PIN_LIKE_COUNT = 3;
 
     private final UserRepository userRepository;

--- a/src/main/java/issueissyu/backend/domain/collection/service/command/CollectionUnlockServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/collection/service/command/CollectionUnlockServiceImpl.java
@@ -1,0 +1,78 @@
+package issueissyu.backend.domain.collection.service.command;
+
+import issueissyu.backend.domain.collection.dto.res.NewlyUnlockedCollectionResDTO;
+import issueissyu.backend.domain.collection.entity.CustomCollection;
+import issueissyu.backend.domain.collection.entity.mapping.UserCustomCollection;
+import issueissyu.backend.domain.collection.repository.CustomCollectionRepository;
+import issueissyu.backend.domain.collection.repository.UserCustomCollectionRepository;
+import issueissyu.backend.domain.pin.repository.PinLikeRepository;
+import issueissyu.backend.domain.user.entity.User;
+import issueissyu.backend.domain.user.repository.UserRepository;
+import issueissyu.backend.global.api.code.GeneralErrorCode;
+import issueissyu.backend.global.exception.GeneralException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CollectionUnlockServiceImpl implements CollectionUnlockService {
+
+    private static final long LIKE_MISSION_COLLECTION_ID = 10L;
+    private static final int REQUIRED_PIN_LIKE_COUNT = 3;
+
+    private final UserRepository userRepository;
+    private final CustomCollectionRepository customCollectionRepository;
+    private final UserCustomCollectionRepository userCustomCollectionRepository;
+    private final PinLikeRepository pinLikeRepository;
+
+    @Override
+    @Transactional
+    public List<NewlyUnlockedCollectionResDTO> evaluateAndUnlockMissions(String uid) {
+        List<NewlyUnlockedCollectionResDTO> newlyUnlocked = new ArrayList<>();
+        unlockLikeMissionIfEligible(uid, newlyUnlocked);
+        return newlyUnlocked;
+    }
+
+    private void unlockLikeMissionIfEligible(String uid, List<NewlyUnlockedCollectionResDTO> newlyUnlocked) {
+        
+        // 해금 되어있으면 패스
+        if (userCustomCollectionRepository
+                .findByUser_UidAndCustomCollection_CustomCollectionId(uid, LIKE_MISSION_COLLECTION_ID)
+                .isPresent()) {
+            return;
+        }
+
+        // 조건 확인
+        if (pinLikeRepository.countByUser_Uid(uid) < REQUIRED_PIN_LIKE_COUNT) {
+            return;
+        }
+
+        // 컬렉션이 있는지..
+        CustomCollection collection = customCollectionRepository
+                .findById(LIKE_MISSION_COLLECTION_ID)
+                .orElse(null);
+        if (collection == null) {
+            return;
+        }
+
+        // 유저 조회
+        User user = userRepository
+                .findById(uid)
+                .orElseThrow(() -> GeneralException.of(GeneralErrorCode.USER_NOT_FOUND));
+
+        // 컬렉션 해금
+        userCustomCollectionRepository.save(
+                UserCustomCollection.builder().user(user).customCollection(collection).build());
+
+        newlyUnlocked.add(
+                NewlyUnlockedCollectionResDTO.builder()
+                        .collectionId(collection.getCustomCollectionId())
+                        .name(collection.getCustomCollectionName())
+                        .imageUrl(collection.getCustomCollectionS3Url())
+                        .unlockCondition(collection.getLockCondition())
+                        .build());
+    }
+}

--- a/src/main/java/issueissyu/backend/domain/collection/service/command/CollectionUnlockServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/collection/service/command/CollectionUnlockServiceImpl.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CollectionUnlockServiceImpl implements CollectionUnlockService {
 
-    private static final long LIKE_MISSION_COLLECTION_ID = 10L;
+    private static final String LIKE_MISSION_COLLECTION_NAME = "음흉씨";
     private static final int REQUIRED_PIN_LIKE_COUNT = 3;
 
     private final UserRepository userRepository;
@@ -40,7 +40,7 @@ public class CollectionUnlockServiceImpl implements CollectionUnlockService {
         
         // 해금 되어있으면 패스
         if (userCustomCollectionRepository
-                .findByUser_UidAndCustomCollection_CustomCollectionId(uid, LIKE_MISSION_COLLECTION_ID)
+                .findByUser_UidAndCustomCollection_CustomCollectionName(uid, LIKE_MISSION_COLLECTION_NAME)
                 .isPresent()) {
             return;
         }
@@ -52,7 +52,7 @@ public class CollectionUnlockServiceImpl implements CollectionUnlockService {
 
         // 컬렉션이 있는지..
         CustomCollection collection = customCollectionRepository
-                .findById(LIKE_MISSION_COLLECTION_ID)
+                .findByCustomCollectionName(LIKE_MISSION_COLLECTION_NAME)
                 .orElse(null);
         if (collection == null) {
             return;

--- a/src/main/java/issueissyu/backend/domain/collection/service/query/UserCustomCollectionQueryService.java
+++ b/src/main/java/issueissyu/backend/domain/collection/service/query/UserCustomCollectionQueryService.java
@@ -3,6 +3,5 @@ package issueissyu.backend.domain.collection.service.query;
 import issueissyu.backend.domain.collection.dto.res.MyCollectionsResDTO;
 
 public interface UserCustomCollectionQueryService {
-
-    MyCollectionsResDTO getMyCollections(String uid);
+    MyCollectionsResDTO getMyCollections(String uid, boolean checkUnlock);
 }

--- a/src/main/java/issueissyu/backend/domain/collection/service/query/UserCustomCollectionQueryServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/collection/service/query/UserCustomCollectionQueryServiceImpl.java
@@ -1,12 +1,14 @@
 package issueissyu.backend.domain.collection.service.query;
 
 import issueissyu.backend.domain.collection.dto.res.MyCollectionsResDTO;
+import issueissyu.backend.domain.collection.dto.res.NewlyUnlockedCollectionResDTO;
 import issueissyu.backend.domain.collection.dto.res.ProfileCollectionSummaryResDTO;
 import issueissyu.backend.domain.collection.dto.res.UserCollectionItemResDTO;
 import issueissyu.backend.domain.collection.entity.CustomCollection;
 import issueissyu.backend.domain.collection.entity.mapping.UserCustomCollection;
 import issueissyu.backend.domain.collection.repository.CustomCollectionRepository;
 import issueissyu.backend.domain.collection.repository.UserCustomCollectionRepository;
+import issueissyu.backend.domain.collection.service.command.CollectionUnlockService;
 import issueissyu.backend.domain.user.entity.User;
 import issueissyu.backend.domain.user.repository.UserRepository;
 import issueissyu.backend.global.api.code.GeneralErrorCode;
@@ -28,11 +30,16 @@ public class UserCustomCollectionQueryServiceImpl implements UserCustomCollectio
     private final UserRepository userRepository;
     private final CustomCollectionRepository customCollectionRepository;
     private final UserCustomCollectionRepository userCustomCollectionRepository;
+    private final CollectionUnlockService collectionUnlockService;
 
     // 마스터 전부 ID 순으로 내려주고, 해금 행 있으면 북마크 반영 / 프로필 요약은 myCollection
     @Override
-    public MyCollectionsResDTO getMyCollections(String uid) {
+    @Transactional(readOnly = false)
+    public MyCollectionsResDTO getMyCollections(String uid, boolean checkUnlock) {
         User user = userRepository.findById(uid).orElseThrow(() -> GeneralException.of(GeneralErrorCode.USER_NOT_FOUND));
+
+        List<NewlyUnlockedCollectionResDTO> newlyUnlocked =
+                checkUnlock ? collectionUnlockService.evaluateAndUnlockMissions(uid) : List.of();
 
         List<CustomCollection> catalogDefinitions =
                 customCollectionRepository.findAllByOrderByCustomCollectionIdAsc();
@@ -66,6 +73,7 @@ public class UserCustomCollectionQueryServiceImpl implements UserCustomCollectio
                 .nickname(user.getNickname())
                 .myCollection(profileSummary)
                 .collections(collections)
+                .newlyUnlocked(newlyUnlocked)
                 .build();
     }
 

--- a/src/main/java/issueissyu/backend/domain/pin/repository/PinLikeRepository.java
+++ b/src/main/java/issueissyu/backend/domain/pin/repository/PinLikeRepository.java
@@ -13,6 +13,8 @@ public interface PinLikeRepository extends JpaRepository<PinLike, Long> {
 
     boolean existsByPin_PinIdAndUser_Uid(Long pinId, String uid);
 
+    long countByUser_Uid(String uid);
+
     @EntityGraph(attributePaths = "user")
     List<PinLike> findByPin_PinId(Long pinId);
 


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #234 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
회원가입 시 '무관심' 과 '행복양' 컬렉션을 추가로 지급합니다.
컬렉션 조회 시 '음흉씨' 의 해금 조건에 맞으면, 해당 컬렉션을 해금합니다.

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
1. 회원가입 및 온보딩 완료 시 '무관심'과, '행복양' 컬렉션 지급
<img width="2320" height="802" alt="image" src="https://github.com/user-attachments/assets/7c34984a-b1d1-4bac-b011-1c2d421ce7fc" />
2. 마이페이지 조회 시에는 checkUnlocked = false
<img width="1420" height="1050" alt="image" src="https://github.com/user-attachments/assets/78e5e158-5838-45cd-ba51-a6d3fac7eae0" />
3. 핀 공감 3개 후 다시 목록 조회 ( 배포 DB 기준으로 id = 10 으로 해놔서 감자빵 입니당..ㅎㅎ )
<img width="1432" height="1084" alt="image" src="https://github.com/user-attachments/assets/e4eb2187-cbd9-4801-b514-d5ddc321cc54" />
4. collection_id = 10 들어왔는지 확인
<img width="2306" height="724" alt="image" src="https://github.com/user-attachments/assets/0859059d-e79e-4e33-9e27-da33eefbbb2d" />
5. 다시 목록 조회 ( new 에 없어야 함 )
<img width="1446" height="1026" alt="image" src="https://github.com/user-attachments/assets/5d60637f-bc50-49fe-b577-8ce91e8e7bea" />


[ 프론트 API 연결 ]
마이페이지와 컬렉션 화면에서 동일 API 를 사용하기 때문에..! 
아래와 같이 연결 부탁 ㅎㅎ..

1. 마이페이지에서는 checkUnlocked = false 로
2. 컬렉션 화면 진입 시 checkUnlocked  = true 로
3. 리스트가 채워져 있으면 해금 달성? 화면 띄우기 -> 모달 닫고 동일 데이터로 UI 갱신

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.