### PR TITLE
[BUG] 소통 핀 이미지 수정 시 업데이트 시간 갱신

### DIFF
--- a/src/main/java/issueissyu/backend/domain/pin/repository/PinRepository.java
+++ b/src/main/java/issueissyu/backend/domain/pin/repository/PinRepository.java
@@ -2,6 +2,7 @@ package issueissyu.backend.domain.pin.repository;
 
 import issueissyu.backend.domain.pin.entity.Pin;
 import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -39,4 +40,12 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
 
     @Query("select p.likeCount from Pin p where p.pinId = :pinId")
     Optional<Integer> findLikeCountByPinId(@Param("pinId") Long pinId);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = false)
+    @Query("""
+            update Pin p
+            set p.updatedAt = :ts
+            where p.pinId = :pinId
+            """)
+    int bumpUpdatedAt(@Param("pinId") Long pinId, @Param("ts") LocalDateTime ts);
 }

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinCommunicationCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinCommunicationCommandServiceImpl.java
@@ -226,9 +226,11 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
                             || !Objects.equals(pin.getPinContent(), req.pinContent());
             pin.updatePinDetails(req.pinTitle(), req.pinContent());
 
+            LocalDateTime responseUpdatedAt = pin.getUpdatedAt();
             // pin_image 변경만 있는 경우에는 pin row가 갱신되지 않으므로 updated_at을 명시적으로 갱신한다.
             if (pinImageChanged && !pinDetailsChanged) {
-                pinRepository.bumpUpdatedAt(pinId, LocalDateTime.now());
+                responseUpdatedAt = LocalDateTime.now();
+                pinRepository.bumpUpdatedAt(pinId, responseUpdatedAt);
             }
 
             PinLocation pinLocation =
@@ -239,7 +241,8 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
             return toEditRes(
                     pin,
                     pinLocation.getLocation().getRegion(),
-                    pinLocation.getDetailAddress());
+                    pinLocation.getDetailAddress(),
+                    responseUpdatedAt);
         } catch (PinException e) {
             throw e;
         } catch (Exception e) {
@@ -376,7 +379,8 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
                 pin.getUpdatedAt());
     }
 
-    private CommunicationPinEditResDTO toEditRes(Pin pin, String region, String pinDetailAddress) {
+    private CommunicationPinEditResDTO toEditRes(
+            Pin pin, String region, String pinDetailAddress, LocalDateTime updatedAt) {
         List<PinImageWithIdResDTO> imgs =
                 pin.getPinImages().stream()
                         .sorted(java.util.Comparator.comparing(PinImage::getPinImageId))
@@ -396,7 +400,7 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
                 imgs,
                 pin.getToneType().name(),
                 pin.getCreatedAt(),
-                pin.getUpdatedAt());
+                updatedAt);
     }
 
     private static void validateCommunicationEditPinImages(List<PinImageItemReqDTO> items) {

--- a/src/main/java/issueissyu/backend/domain/pin/service/command/PinCommunicationCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/pin/service/command/PinCommunicationCommandServiceImpl.java
@@ -44,6 +44,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -213,15 +214,22 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
         }
 
         try {
+            boolean pinImageChanged = false;
             if (req.pinImageUrls() != null) {
                 assertPinImageUrlsBelongToPin(pinId, req.pinImageUrls());
                 validateCommunicationEditPinImages(req.pinImageUrls());
-                syncPinImages(pin, req.pinImageUrls());
+                pinImageChanged = syncPinImages(pin, req.pinImageUrls());
             }
 
+            boolean pinDetailsChanged =
+                    !Objects.equals(pin.getPinTitle(), req.pinTitle())
+                            || !Objects.equals(pin.getPinContent(), req.pinContent());
             pin.updatePinDetails(req.pinTitle(), req.pinContent());
 
-            pinRepository.save(pin);
+            // pin_image 변경만 있는 경우에는 pin row가 갱신되지 않으므로 updated_at을 명시적으로 갱신한다.
+            if (pinImageChanged && !pinDetailsChanged) {
+                pinRepository.bumpUpdatedAt(pinId, LocalDateTime.now());
+            }
 
             PinLocation pinLocation =
                     pinLocationRepository
@@ -276,10 +284,14 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
         validateMainFlags(merged, PinErrorCode.PIN_EDIT_COMMUNICATION_400_1);
     }
 
-    private void syncPinImages(Pin pin, List<PinImageItemReqDTO> items) {
+    private boolean syncPinImages(Pin pin, List<PinImageItemReqDTO> items) {
+        boolean changed = false;
         Set<String> keepUrls = items.stream().map(PinImageItemReqDTO::pinImageUrl).collect(Collectors.toSet());
 
-        pin.getPinImages().removeIf(pi -> !keepUrls.contains(pi.getPinS3Url()));
+        boolean removedAny = pin.getPinImages().removeIf(pi -> !keepUrls.contains(pi.getPinS3Url()));
+        if (removedAny) {
+            changed = true;
+        }
 
         for (PinImageItemReqDTO item : items) {
             PinImage row =
@@ -292,8 +304,13 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
                                                     .orElse(null));
 
             if (row != null) {
-                attachIfAbsent(pin, row);
-                row.setMainImage(item.isMain());
+                if (attachIfAbsent(pin, row)) {
+                    changed = true;
+                }
+                if (row.isMainImage() != item.isMain()) {
+                    row.setMainImage(item.isMain());
+                    changed = true;
+                }
             } else {
                 String key = PinS3UrlSupport.extractKey(item.pinImageUrl(), amazonConfig);
                 PinImage created =
@@ -303,8 +320,10 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
                                 .mainImage(item.isMain())
                                 .build();
                 pin.addPinImage(created);
+                changed = true;
             }
         }
+        return changed;
     }
 
     // pin_image 테이블에서 동일 URL이 있으면, 현재 수정 중인 핀에 속한 행이면 해당 pin_image(row)를 그대로 사용합니다.
@@ -314,13 +333,15 @@ public class PinCommunicationCommandServiceImpl implements PinCommunicationComma
                 .findFirst();
     }
 
-    private static void attachIfAbsent(Pin pin, PinImage candidate) {
+    private static boolean attachIfAbsent(Pin pin, PinImage candidate) {
         boolean alreadyAttached =
                 pin.getPinImages().stream()
                         .anyMatch(pi -> pinImageRefsEqual(pi, candidate));
-        if (!alreadyAttached) {
-            pin.addPinImage(candidate);
+        if (alreadyAttached) {
+            return false;
         }
+        pin.addPinImage(candidate);
+        return true;
     }
 
     private static boolean pinImageRefsEqual(PinImage a, PinImage b) {


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #282 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.

UI의 수정됨 표기를 위해 소통 핀 이미지 수정 시, pin 테이블의 updated_at 시간을 갱신합니다.

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.