### PR TITLE
[FEAT] 구글 결제 완료 신호 보내기 기능 구현

### DIFF
--- a/src/main/java/issueissyu/backend/domain/billing/service/command/BillingPurchaseCommandServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/billing/service/command/BillingPurchaseCommandServiceImpl.java
@@ -3,6 +3,7 @@ package issueissyu.backend.domain.billing.service.command;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.androidpublisher.AndroidPublisher;
 import com.google.api.services.androidpublisher.model.ProductPurchase;
+import com.google.api.services.androidpublisher.model.ProductPurchasesAcknowledgeRequest;
 import issueissyu.backend.domain.billing.converter.BillingConverter;
 import issueissyu.backend.domain.billing.dto.req.VerifyPurchaseReq;
 import issueissyu.backend.domain.billing.exception.BillingException;
@@ -95,7 +96,7 @@ public class BillingPurchaseCommandServiceImpl implements BillingPurchaseCommand
                 throw BillingException.of(BillingErrorCode.PURCHASE_TOKEN_INVALID);
             }
 
-            // consume/acknowledge는 앱 정책 확정 후 추가
+            acknowledgeIfNeeded(androidPublisher, productId, purchaseToken, purchase);
         } catch (GoogleJsonResponseException e) {
             int statusCode = e.getStatusCode();
             if (statusCode == 400 || statusCode == 404 || statusCode == 410) {
@@ -107,5 +108,28 @@ public class BillingPurchaseCommandServiceImpl implements BillingPurchaseCommand
             log.error("[Billing] Google Play API 통신 실패 - {}", e.getMessage());
             throw BillingException.of(BillingErrorCode.GOOGLE_PLAY_API_ERROR);
         }
+    }
+
+    private void acknowledgeIfNeeded(
+            AndroidPublisher androidPublisher,
+            String productId,
+            String purchaseToken,
+            ProductPurchase purchase
+    ) throws IOException {
+        // 0 = Yet to be acknowledged, 1 = Acknowledged
+        Integer acknowledgementState = purchase.getAcknowledgementState();
+        if (acknowledgementState != null && acknowledgementState == 1) {
+            return;
+        }
+
+        androidPublisher.purchases()
+                .products()
+                .acknowledge(
+                        packageName,
+                        productId,
+                        purchaseToken,
+                        new ProductPurchasesAcknowledgeRequest()
+                )
+                .execute();
     }
 }

--- a/src/main/java/issueissyu/backend/global/config/GooglePlayConfig.java
+++ b/src/main/java/issueissyu/backend/global/config/GooglePlayConfig.java
@@ -10,32 +10,52 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.Resource;
+import org.springframework.util.StringUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
+import java.util.Base64;
 
 @Configuration
 @ConditionalOnProperty(name = "billing.google-verification-enabled", havingValue = "true")
 public class GooglePlayConfig {
 
-    @Value("${google.play.credentials-path}")
-    private Resource credentialsResource;
+    private static final String ANDROID_PUBLISHER_SCOPE = "https://www.googleapis.com/auth/androidpublisher";
+
+    @Value("${google.play.credentials-base64:}")
+    private String credentialsBase64;
 
     @Bean
     public AndroidPublisher androidPublisher() throws IOException, GeneralSecurityException {
-        try (InputStream inputStream = credentialsResource.getInputStream()) {
-            GoogleCredentials credentials = GoogleCredentials
-                    .fromStream(inputStream)
-                    .createScoped("https://www.googleapis.com/auth/androidpublisher");
+        GoogleCredentials credentials = loadCredentials()
+                .createScoped(ANDROID_PUBLISHER_SCOPE);
 
-            HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(credentials);
-            return new AndroidPublisher.Builder(
-                    GoogleNetHttpTransport.newTrustedTransport(),
-                    GsonFactory.getDefaultInstance(),
-                    requestInitializer
-            ).setApplicationName("issueissyu").build();
+        HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(credentials);
+        return new AndroidPublisher.Builder(
+                GoogleNetHttpTransport.newTrustedTransport(),
+                GsonFactory.getDefaultInstance(),
+                requestInitializer
+        ).setApplicationName("issueissyu").build();
+    }
+
+    private GoogleCredentials loadCredentials() throws IOException {
+        if (!StringUtils.hasText(credentialsBase64)) {
+            throw new IllegalStateException(
+                    "billing.google-verification-enabled=true 이지만 GOOGLE_PLAY_CREDENTIALS_BASE64 가 비어 있습니다."
+            );
+        }
+
+        byte[] decoded;
+        try {
+            decoded = Base64.getDecoder().decode(credentialsBase64.replaceAll("\\s", ""));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("GOOGLE_PLAY_CREDENTIALS_BASE64 디코딩에 실패했습니다.", e);
+        }
+
+        try (InputStream inputStream = new ByteArrayInputStream(decoded)) {
+            return GoogleCredentials.fromStream(inputStream);
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,11 +28,6 @@ solapi:
 billing:
   google-verification-enabled: ${BILLING_GOOGLE_VERIFICATION_ENABLED:false}
 
-google:
-  play:
-    credentials-path: ${GOOGLE_PLAY_CREDENTIALS_PATH:}
-    package-name: ${GOOGLE_PLAY_PACKAGE_NAME:}
-
 cloud:
   aws:
     credentials:
@@ -174,3 +169,10 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+billing:
+  google-verification-enabled: ${BILLING_GOOGLE_VERIFICATION_ENABLED:true}
+
+google:
+  play:
+    credentials-base64: ${GOOGLE_PLAY_CREDENTIALS_BASE64:}
+    package-name: ${GOOGLE_PLAY_PACKAGE_NAME:}


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #16 

## ✨ 작업 개요
환경별로 Google API 호출 여부를 제어할 수 있도록 BILLING_GOOGLE_VERIFICATION_ENABLED 플래그 사용 

LOCAL=false: Google API 호출 없이 DB 저장만 수행
DEVELOP=true: Google API로 purchaseToken 검증

- 서버에서 결제 acknowledge 처리
- Google Service Account JSON을 Base64 인코딩하여 env로 관리
- application.yml 결제 검증 설정 추가

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.