### PR TITLE
[BUG] 지도 핀 조회 응답에 할인 정보 추가

### DIFF
--- a/src/main/java/issueissyu/backend/domain/location/repository/PinLocationRepository.java
+++ b/src/main/java/issueissyu/backend/domain/location/repository/PinLocationRepository.java
@@ -40,7 +40,8 @@ public interface PinLocationRepository extends JpaRepository<PinLocation, Long> 
                 ST_Y(pl.pin_point) AS lat,
                 ST_X(pl.pin_point) AS lng,
                 pl.detail_address  AS detailAddress,
-                l.location         AS region
+                l.location         AS region,
+                CASE WHEN p.pin_type = 'STORE' THEN ep.discount ELSE NULL END AS discount
             FROM pin_location pl
             INNER JOIN pin      p ON pl.pin_id      = p.pin_id
             INNER JOIN location l ON pl.location_id = l.location_id
@@ -79,7 +80,8 @@ public interface PinLocationRepository extends JpaRepository<PinLocation, Long> 
                 pl.detail_address AS detailAddress,
                 l.location AS region,
                 ST_Y(ST_SnapToGrid(pl.pin_point, :gridSize)) AS clusterLat,
-                ST_X(ST_SnapToGrid(pl.pin_point, :gridSize)) AS clusterLng
+                ST_X(ST_SnapToGrid(pl.pin_point, :gridSize)) AS clusterLng,
+                CASE WHEN p.pin_type = 'STORE' THEN ep.discount ELSE NULL END AS discount
             FROM pin_location pl
             INNER JOIN pin      p ON pl.pin_id      = p.pin_id
             INNER JOIN location l ON pl.location_id = l.location_id

--- a/src/main/java/issueissyu/backend/domain/map/dto/res/MapPinClusterView.java
+++ b/src/main/java/issueissyu/backend/domain/map/dto/res/MapPinClusterView.java
@@ -16,4 +16,6 @@ public interface MapPinClusterView {
     Double getClusterLat();
 
     Double getClusterLng();
+
+    String getDiscount();
 }

--- a/src/main/java/issueissyu/backend/domain/map/dto/res/MapPinResDTO.java
+++ b/src/main/java/issueissyu/backend/domain/map/dto/res/MapPinResDTO.java
@@ -10,7 +10,8 @@ public record MapPinResDTO(List<PinItemDTO> pins) {
             double latitude,              // 위도 (latitude)
             double longitude,             // 경도 (longitude)
             String pinDetailAddress,
-            String pinLocation
+            String pinLocation,
+            String discount
     ) {
     }
 }

--- a/src/main/java/issueissyu/backend/domain/map/dto/res/MapPinView.java
+++ b/src/main/java/issueissyu/backend/domain/map/dto/res/MapPinView.java
@@ -9,4 +9,5 @@ public interface MapPinView {
     Double getLng();      // ST_X(pin_point) → 경도
     String getDetailAddress();
     String getRegion();   // location.location 컬럼 (법정동 주소 문자열)
+    String getDiscount();
 }

--- a/src/main/java/issueissyu/backend/domain/map/service/query/MapPinQueryServiceImpl.java
+++ b/src/main/java/issueissyu/backend/domain/map/service/query/MapPinQueryServiceImpl.java
@@ -88,7 +88,8 @@ public class MapPinQueryServiceImpl implements MapPinQueryService {
                 view.getLat(),
                 view.getLng(),
                 view.getDetailAddress(),
-                view.getRegion()
+                view.getRegion(),
+                view.getDiscount()
         );
     }
 
@@ -99,7 +100,8 @@ public class MapPinQueryServiceImpl implements MapPinQueryService {
                 view.getLat(),
                 view.getLng(),
                 view.getDetailAddress(),
-                view.getRegion()
+                view.getRegion(),
+                view.getDiscount()
         );
     }
 


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #363

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.

지도 핀 조회 응답에 할인 정보를 추가합니다.

- GET /api/map/pins?swLat={남서_위도}&swLng={남서_경도}&neLat={북동_위도}&neLng={북동_경도}&category={카테고리} -> 현재화면 핀 조회
- GET /api/map/clustering/pins?swLat={남서_위도}&swLng={남서_경도}&neLat={북동_위도}&neLng={북동_경도}&category={카테고리}&zoomLevel={줌레벨} -> 핀 클러스터링 조회

두 API에 할인정보가 추가되었습니다.

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!
<img width="1582" height="807" alt="image" src="https://github.com/user-attachments/assets/b2fc9702-71da-4510-8844-4a0540b09597" />


## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.